### PR TITLE
test: Halmos symbolic proofs for protocol invariants

### DIFF
--- a/test/halmos/PaySymbolicProofs.sol
+++ b/test/halmos/PaySymbolicProofs.sol
@@ -188,8 +188,7 @@ contract PaySymbolicProofs is Test {
 
         // Expected fee: max(MIN_ACTIVATION_FEE, amount / 100)
         uint96 percentFee = amount / 100;
-        uint96 expectedFee =
-            percentFee > PayTypes.MIN_ACTIVATION_FEE ? percentFee : PayTypes.MIN_ACTIVATION_FEE;
+        uint96 expectedFee = percentFee > PayTypes.MIN_ACTIVATION_FEE ? percentFee : PayTypes.MIN_ACTIVATION_FEE;
 
         // INV: activation fee matches formula
         assert(t.activationFee == expectedFee);


### PR DESCRIPTION
## Summary
5 symbolic proofs for Pay protocol safety properties, verified by Halmos for ALL possible inputs.

## Properties
| ID | Property | Contract |
|----|----------|----------|
| P1 | Fee correctness: fee = floor(amount * bps / 10000), no dust | PayFee |
| P2 | Direct payment conservation: provider + fee = amount | PayDirect |
| P3 | Tab locks exact amount: agent loses exactly amount USDC | PayTab |
| P4 | Activation fee formula: max(MIN_ACT_FEE, amount/100) | PayTab |
| P5 | No double close: second closeTab always reverts | PayTab |

## Test plan
- [ ] CI passes (forge build)
- [ ] Halmos run via pay-audit CI (separate step)