### PR TITLE
add mainnet deploy script and workflow

### DIFF
--- a/.github/workflows/deploy-mainnet.yml
+++ b/.github/workflows/deploy-mainnet.yml
@@ -1,0 +1,55 @@
+name: Deploy Mainnet
+
+concurrency:
+  group: deploy-mainnet
+  cancel-in-progress: false
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Simulate only (no broadcast)"
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment: production
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          submodules: recursive
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@8789b3e21e6c11b2697f5eb56eddae542f746c10 # v1
+        with:
+          version: nightly-c07d504b4ae67754584f4e05ff0c547a43c50f7b
+
+      - name: Build
+        run: forge build
+
+      - name: Run mainnet deploy script
+        env:
+          FOUNDRY_PRIVATE_KEY: ${{ secrets.DEPLOYER_PRIVATE_KEY }}
+          BASE_MAINNET_RPC_URL: ${{ secrets.BASE_MAINNET_RPC_URL }}
+          BASESCAN_API_KEY: ${{ secrets.BASESCAN_API_KEY }}
+        run: |
+          FLAGS="--rpc-url $BASE_MAINNET_RPC_URL -vvvv"
+          if [ "${{ inputs.dry_run }}" = "false" ]; then
+            FLAGS="$FLAGS --broadcast --slow --verify --etherscan-api-key $BASESCAN_API_KEY"
+          fi
+          forge script script/DeployMainnet.s.sol --private-key "$FOUNDRY_PRIVATE_KEY" $FLAGS
+
+      - name: Upload broadcast artifacts
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        if: always()
+        with:
+          name: broadcast-mainnet-${{ github.run_number }}
+          path: broadcast/**/*.json
+          retention-days: 90

--- a/script/DeployMainnet.s.sol
+++ b/script/DeployMainnet.s.sol
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {Script, console2} from "forge-std/Script.sol";
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+
+import {PayFee} from "../src/PayFee.sol";
+import {PayDirect} from "../src/PayDirect.sol";
+import {PayTab} from "../src/PayTab.sol";
+import {PayRouter} from "../src/PayRouter.sol";
+
+/// @title DeployMainnet
+/// @notice Mainnet deployment script for Base. Uses real USDC.
+///         The deployer address serves as: owner, fee wallet, and relayer.
+///
+/// @dev Run with:
+///      forge script script/DeployMainnet.s.sol \
+///        --broadcast \
+///        --rpc-url $BASE_MAINNET_RPC_URL \
+///        --private-key $DEPLOYER_PRIVATE_KEY \
+///        --verify \
+///        --etherscan-api-key $BASESCAN_API_KEY
+contract DeployMainnet is Script {
+    /// @dev USDC on Base mainnet.
+    address constant USDC = 0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913;
+
+    address internal _payFeeProxy;
+    address internal _payDirect;
+    address internal _payTab;
+    address internal _payRouterProxy;
+
+    function run() external {
+        address deployer = msg.sender;
+
+        console2.log("=== Pay Protocol - Mainnet Deployment (Base) ===");
+        console2.log("Deployer / Owner / FeeWallet / Relayer:", deployer);
+        console2.log("USDC:", USDC);
+        console2.log("");
+
+        vm.startBroadcast();
+
+        _deployPayFee(deployer);
+        _deployPayDirect(deployer);
+        _deployPayTab(deployer);
+        _deployPayRouter(deployer);
+        _authorizeCallers();
+        _authorizeRelayer(deployer);
+
+        vm.stopBroadcast();
+
+        _logSummary(deployer);
+    }
+
+    /// @dev Deploy PayFee behind UUPS proxy. Deployer is owner.
+    function _deployPayFee(address owner) internal {
+        PayFee impl = new PayFee();
+        bytes memory initData = abi.encodeCall(impl.initialize, (owner));
+        _payFeeProxy = address(new ERC1967Proxy(address(impl), initData));
+        console2.log("PayFee (proxy):    ", _payFeeProxy);
+    }
+
+    /// @dev Deploy PayDirect (immutable). Deployer is fee wallet and relayer.
+    function _deployPayDirect(address deployer) internal {
+        _payDirect = address(new PayDirect(USDC, _payFeeProxy, deployer, deployer));
+        console2.log("PayDirect:         ", _payDirect);
+    }
+
+    /// @dev Deploy PayTab (immutable). Deployer is fee wallet and relayer.
+    function _deployPayTab(address deployer) internal {
+        _payTab = address(new PayTab(USDC, _payFeeProxy, deployer, deployer));
+        console2.log("PayTab:            ", _payTab);
+    }
+
+    /// @dev Deploy PayRouter behind UUPS proxy. Deployer is owner and fee wallet.
+    function _deployPayRouter(address deployer) internal {
+        PayRouter impl = new PayRouter();
+        bytes memory initData = abi.encodeCall(impl.initialize, (deployer, USDC, _payFeeProxy, deployer));
+        _payRouterProxy = address(new ERC1967Proxy(address(impl), initData));
+        console2.log("PayRouter (proxy): ", _payRouterProxy);
+    }
+
+    /// @dev Authorize PayDirect, PayTab, and PayRouter to call recordTransaction on PayFee.
+    function _authorizeCallers() internal {
+        PayFee feeProxy = PayFee(_payFeeProxy);
+        feeProxy.authorizeCaller(_payDirect);
+        feeProxy.authorizeCaller(_payTab);
+        feeProxy.authorizeCaller(_payRouterProxy);
+        console2.log("PayFee: authorized PayDirect, PayTab, PayRouter");
+    }
+
+    /// @dev Authorize the deployer as a relayer on PayRouter (for x402 settlements).
+    function _authorizeRelayer(address deployer) internal {
+        PayRouter(_payRouterProxy).authorizeRelayer(deployer);
+        console2.log("PayRouter: authorized relayer", deployer);
+    }
+
+    function _logSummary(address deployer) internal view {
+        console2.log("");
+        console2.log("=== Deployment Complete ===");
+        console2.log("Network:           Base Mainnet (chainId 8453)");
+        console2.log("Deployer:          ", deployer);
+        console2.log("");
+        console2.log("--- Contracts ---");
+        console2.log("USDC (native):     ", USDC);
+        console2.log("PayFee (proxy):    ", _payFeeProxy);
+        console2.log("PayDirect:         ", _payDirect);
+        console2.log("PayTab:            ", _payTab);
+        console2.log("PayRouter (proxy): ", _payRouterProxy);
+        console2.log("");
+        console2.log("--- Server .env snippet ---");
+        console2.log("CHAIN_ID=8453");
+        console2.log("RPC_URL=<base_mainnet_rpc_url>");
+        console2.log("RELAYER_PRIVATE_KEY=<deployer_private_key>");
+        console2.log("USDC_ADDRESS=", USDC);
+        console2.log("PAY_FEE_ADDRESS=", _payFeeProxy);
+        console2.log("PAY_DIRECT_ADDRESS=", _payDirect);
+        console2.log("PAY_TAB_ADDRESS=", _payTab);
+        console2.log("PAY_ROUTER_ADDRESS=", _payRouterProxy);
+        console2.log("FEE_WALLET=", deployer);
+    }
+}


### PR DESCRIPTION
## Summary
- `DeployMainnet.s.sol`: Mainnet deploy script using real USDC on Base (`0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913`)
- `deploy-mainnet.yml`: Manual dispatch workflow with dry_run (default true), production environment, BaseScan verification
- No MockUSDC — uses native USDC contract on Base

## Differences from testnet
- Real USDC address (not MockUSDC deployment)
- Chain ID 8453 (Base mainnet vs 84532 Base Sepolia)
- BaseScan verification (vs Blockscout for testnet)
- `production` GitHub environment (vs `testnet`)

## Test plan
- [x] Script compiles (mirrors testnet structure)
- [ ] Dry-run mainnet deploy after merge (via workflow dispatch)
- [ ] Live broadcast after dry-run verification

## Required secrets (production environment)
- `DEPLOYER_PRIVATE_KEY`
- `BASE_MAINNET_RPC_URL`
- `BASESCAN_API_KEY`