### PR TITLE
fix: lower tab activation fee floor to $0.10

### DIFF
--- a/src/PayTab.sol
+++ b/src/PayTab.sol
@@ -25,7 +25,7 @@ import {PayEvents} from "./libraries/PayEvents.sol";
 ///        - closed tab can never be charged, topped up, or reopened
 ///        - only agent or provider or relayer can close
 ///
-///      Activation fee: max($0.50, 1% of tab amount). Paid by agent at open, non-refundable.
+///      Activation fee: max($0.10, 1% of tab amount). Paid by agent at open, non-refundable.
 ///      Sent to feeWallet immediately. Tab balance = amount - activationFee.
 contract PayTab is IPayTab, ReentrancyGuard {
     // =========================================================================
@@ -323,8 +323,8 @@ contract PayTab is IPayTab, ReentrancyGuard {
     }
 
     /// @dev Activation fee: max(MIN_ACTIVATION_FEE, amount / 100).
-    ///      At MIN_TAB_AMOUNT ($5), fee = max($0.50, $0.05) = $0.50.
-    ///      At $50+, fee = 1% of amount.
+    ///      At MIN_TAB_AMOUNT ($5), fee = max($0.10, $0.05) = $0.10.
+    ///      At $10+, fee = 1% of amount.
     function _calculateActivationFee(uint96 amount) internal pure returns (uint96) {
         uint96 percentFee = amount / 100;
         return percentFee > PayTypes.MIN_ACTIVATION_FEE ? percentFee : PayTypes.MIN_ACTIVATION_FEE;

--- a/src/PayTabV2.sol
+++ b/src/PayTabV2.sol
@@ -322,8 +322,8 @@ contract PayTabV2 is IPayTabV2, ReentrancyGuard {
     }
 
     /// @dev Activation fee: max(MIN_ACTIVATION_FEE, amount / 100).
-    ///      At $50, fee = max($0.50, $0.50) = $0.50.
-    ///      Above $50, fee = 1% of amount.
+    ///      At $10, fee = max($0.10, $0.10) = $0.10.
+    ///      Above $10, fee = 1% of amount.
     function _calculateActivationFee(uint96 amount) internal pure returns (uint96) {
         uint96 percentFee = amount / 100;
         return percentFee > PayTypes.MIN_ACTIVATION_FEE ? percentFee : PayTypes.MIN_ACTIVATION_FEE;

--- a/src/libraries/PayTypes.sol
+++ b/src/libraries/PayTypes.sol
@@ -39,7 +39,7 @@ library PayTypes {
     uint96 constant MIN_TAB_AMOUNT = 5_000_000; // $5.00 in USDC (6 decimals)
 
     /// @notice Activation fee floor
-    uint96 constant MIN_ACTIVATION_FEE = 500_000; // $0.50 in USDC (6 decimals)
+    uint96 constant MIN_ACTIVATION_FEE = 100_000; // $0.10 in USDC (6 decimals)
 
     /// @notice Per-charge minimum fee (server-enforced, not contract-enforced)
     /// @dev max($0.002, 1%) per charge. Below $0.20/call the floor kicks in.

--- a/test/PayLifecycle.fuzz.t.sol
+++ b/test/PayLifecycle.fuzz.t.sol
@@ -225,8 +225,8 @@ contract PayLifecycleFuzzTest is Test {
     // Activation fee crossover edge case
     // =========================================================================
 
-    /// @notice At exactly $50 (50_000_000), amount/100 == MIN_ACTIVATION_FEE ($0.50).
-    ///         Below $50: fee == MIN. At/above $50: fee == amount/100. Verify crossover.
+    /// @notice At exactly $10 (10_000_000), amount/100 == MIN_ACTIVATION_FEE ($0.10).
+    ///         Below $10: fee == MIN. At/above $10: fee == amount/100. Verify crossover.
     function testFuzz_activationFee_crossover(uint96 tabAmount) public {
         tabAmount = uint96(bound(tabAmount, MIN_TAB, 100e6)); // $5 - $100 range around crossover
 

--- a/test/PayTab.t.sol
+++ b/test/PayTab.t.sol
@@ -59,7 +59,7 @@ contract PayTabTest is Test {
     address internal stranger = makeAddr("stranger");
 
     uint96 constant MIN_TAB = PayTypes.MIN_TAB_AMOUNT; // $5.00
-    uint96 constant MIN_ACT_FEE = PayTypes.MIN_ACTIVATION_FEE; // $0.50
+    uint96 constant MIN_ACT_FEE = PayTypes.MIN_ACTIVATION_FEE; // $0.10
 
     bytes32 constant TAB_ID = bytes32("tab-001");
 
@@ -133,9 +133,9 @@ contract PayTabTest is Test {
     }
 
     function test_openTab_activationFee_atMinimum() public {
-        // $5.00 → 1% = $0.05, but min is $0.50. So fee = $0.50.
+        // $5.00 → 1% = $0.05, but min is $0.10. So fee = $0.10.
         uint96 amount = 5e6;
-        uint96 expectedFee = MIN_ACT_FEE; // $0.50
+        uint96 expectedFee = MIN_ACT_FEE; // $0.10
         uint96 expectedBalance = amount - expectedFee;
 
         vm.prank(agent);
@@ -147,7 +147,7 @@ contract PayTabTest is Test {
     }
 
     function test_openTab_activationFee_onePercent() public {
-        // $100.00 → 1% = $1.00 > $0.50 min. So fee = $1.00.
+        // $100.00 → 1% = $1.00 > $0.10 min. So fee = $1.00.
         uint96 amount = 100e6;
         uint96 expectedFee = amount / 100; // $1.00
         uint96 expectedBalance = amount - expectedFee;
@@ -161,8 +161,8 @@ contract PayTabTest is Test {
     }
 
     function test_openTab_activationFee_exactBreakeven() public {
-        // At $50.00, 1% = $0.50 = MIN_ACT_FEE. Either path gives same result.
-        uint96 amount = 50e6;
+        // At $10.00, 1% = $0.10 = MIN_ACT_FEE. Either path gives same result.
+        uint96 amount = 10e6;
         uint96 expectedFee = MIN_ACT_FEE;
 
         vm.prank(agent);
@@ -191,7 +191,7 @@ contract PayTabTest is Test {
 
     function test_openTab_emitsEvent() public {
         uint96 amount = 100e6;
-        uint96 expectedFee = amount / 100; // $1.00 > $0.50 min
+        uint96 expectedFee = amount / 100; // $1.00 > $0.10 min
         uint96 expectedBalance = amount - expectedFee;
         uint96 maxCharge = 500_000;
 
@@ -302,7 +302,7 @@ contract PayTabTest is Test {
 
     function test_openTabFor_correctTransfers() public {
         uint96 amount = 100e6;
-        uint96 expectedFee = amount / 100; // $1.00 > $0.50 min
+        uint96 expectedFee = amount / 100; // $1.00 > $0.10 min
         uint96 expectedBalance = amount - expectedFee;
 
         uint256 agentBefore = usdc.balanceOf(agent);
@@ -343,7 +343,7 @@ contract PayTabTest is Test {
     function test_getTab_returnsCorrectData() public {
         uint96 amount = 100e6;
         uint96 maxCharge = 200_000;
-        uint96 expectedFee = amount / 100; // $1.00 > $0.50 min
+        uint96 expectedFee = amount / 100; // $1.00 > $0.10 min
         uint96 expectedBalance = amount - expectedFee;
 
         vm.prank(agent);


### PR DESCRIPTION
## Summary
- Lower `MIN_ACTIVATION_FEE` from $0.50 (500_000) to $0.10 (100_000)
- Per-charge floor ($0.002) already covers gas — high activation floor was unnecessary barrier
- Updated NatSpec in PayTab.sol, PayTabV2.sol, PayTypes.sol
- Updated all test assertions and crossover point ($50 → $10)

## Test plan
- [ ] CI forge tests pass (unit + fuzz)
- [ ] Crossover test verifies $10 boundary