### PR TITLE
Add PayTabV4 with per-charge fee floor

### DIFF
--- a/src/PayTabV4.sol
+++ b/src/PayTabV4.sol
@@ -1,0 +1,351 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
+
+import {IPayTab} from "./interfaces/IPayTab.sol";
+import {IPayTabV2} from "./interfaces/IPayTabV2.sol";
+import {IPayFee} from "./interfaces/IPayFee.sol";
+import {IUSDC} from "./interfaces/IUSDC.sol";
+import {PayTypes} from "./libraries/PayTypes.sol";
+import {PayErrors} from "./libraries/PayErrors.sol";
+import {PayEvents} from "./libraries/PayEvents.sol";
+
+/// @title PayTabV4
+/// @notice Pre-funded metered account with per-charge fee floor enforcement.
+/// @dev IMMUTABLE — no proxy, no admin key, no upgrade path. Holds USDC.
+///
+///      Changes from v3:
+///        - Fee floor: max(chargesNew * MIN_CHARGE_FEE, unwithdrawn * rateBps / 10_000).
+///          Ensures micropayment tabs pay at least $0.002 per charge in fees.
+///        - New storage: _chargeCountAtLastWithdrawal tracks charges per withdrawal window.
+///
+///      State machine (unchanged from v3):
+///        nonexistent -> active (via openTab)
+///        active -> active (via chargeTab, settleCharges, topUpTab, withdrawCharged)
+///        active -> closed (via closeTab)
+contract PayTabV4 is IPayTabV2, ReentrancyGuard {
+    // =========================================================================
+    // Immutable state (set once in constructor)
+    // =========================================================================
+
+    /// @notice USDC token contract on Base.
+    IUSDC public immutable usdc;
+
+    /// @notice Fee calculator (UUPS proxy).
+    IPayFee public immutable payFee;
+
+    /// @notice Protocol fee wallet — receives activation fees and processing fees.
+    address public immutable feeWallet;
+
+    /// @notice Authorized relayer address.
+    address public immutable relayer;
+
+    // =========================================================================
+    // Storage
+    // =========================================================================
+
+    /// @notice Tab storage. tabId -> Tab struct.
+    mapping(bytes32 => PayTypes.Tab) internal _tabs;
+
+    /// @notice Charge count at last withdrawal, per tab.
+    /// @dev Used to compute charges-since-last-withdrawal for the fee floor.
+    ///      Separate mapping preserves IPayTab interface (getTab returns PayTypes.Tab).
+    mapping(bytes32 => uint256) internal _chargeCountAtLastWithdrawal;
+
+    // =========================================================================
+    // Constructor
+    // =========================================================================
+
+    /// @notice Deploy PayTabV4.
+    /// @param usdc_ USDC token address on Base
+    /// @param payFee_ PayFee calculator (proxy address)
+    /// @param feeWallet_ Protocol fee wallet
+    /// @param relayer_ Authorized relayer address
+    constructor(address usdc_, address payFee_, address feeWallet_, address relayer_) {
+        if (usdc_ == address(0)) revert PayErrors.ZeroAddress();
+        if (payFee_ == address(0)) revert PayErrors.ZeroAddress();
+        if (feeWallet_ == address(0)) revert PayErrors.ZeroAddress();
+        if (relayer_ == address(0)) revert PayErrors.ZeroAddress();
+
+        usdc = IUSDC(usdc_);
+        payFee = IPayFee(payFee_);
+        feeWallet = feeWallet_;
+        relayer = relayer_;
+    }
+
+    // =========================================================================
+    // Modifiers
+    // =========================================================================
+
+    modifier onlyRelayer() {
+        if (msg.sender != relayer) revert PayErrors.Unauthorized(msg.sender);
+        _;
+    }
+
+    // =========================================================================
+    // settleCharges — batch SSTORE (from v2)
+    // =========================================================================
+
+    /// @inheritdoc IPayTabV2
+    /// @dev Only relayer. No USDC transfer — just SSTORE.
+    ///      CEI: checks -> effects -> no interactions.
+    ///      ~35K gas regardless of batch size (3 SSTORE updates + 1 event).
+    function settleCharges(bytes32 tabId, uint96 totalAmount, uint32 chargeCount, uint96 maxSingleCharge)
+        external
+        onlyRelayer
+    {
+        PayTypes.Tab storage t = _tabs[tabId];
+
+        // --- Checks ---
+        if (t.agent == address(0)) revert PayErrors.TabNotFound(tabId);
+        if (t.status != PayTypes.TabStatus.Active) revert PayErrors.TabClosed(tabId);
+        if (totalAmount == 0) revert PayErrors.ZeroAmount();
+        if (totalAmount > t.amount) revert PayErrors.InsufficientBalance(tabId, totalAmount, t.amount);
+        if (maxSingleCharge > t.maxChargePerCall) {
+            revert PayErrors.ChargeLimitExceeded(tabId, maxSingleCharge, t.maxChargePerCall);
+        }
+
+        // --- Effects ---
+        t.amount -= totalAmount;
+        t.totalCharged += totalAmount;
+        t.chargeCount += chargeCount;
+
+        emit PayEvents.TabSettled(tabId, totalAmount, chargeCount, maxSingleCharge, t.amount, t.chargeCount);
+    }
+
+    // =========================================================================
+    // IPayTab — openTab
+    // =========================================================================
+
+    /// @inheritdoc IPayTab
+    function openTab(bytes32 tabId, address provider, uint96 amount, uint96 maxChargePerCall) external nonReentrant {
+        _openTab(msg.sender, tabId, provider, amount, maxChargePerCall);
+    }
+
+    /// @inheritdoc IPayTab
+    function openTabFor(address agent, bytes32 tabId, address provider, uint96 amount, uint96 maxChargePerCall)
+        external
+        nonReentrant
+        onlyRelayer
+    {
+        if (agent == address(0)) revert PayErrors.ZeroAddress();
+        _openTab(agent, tabId, provider, amount, maxChargePerCall);
+    }
+
+    // =========================================================================
+    // IPayTab — chargeTab (retained for backwards compat / single-charge use)
+    // =========================================================================
+
+    /// @inheritdoc IPayTab
+    /// @dev Only relayer. No USDC transfer — just SSTORE.
+    function chargeTab(bytes32 tabId, uint96 amount) external onlyRelayer {
+        PayTypes.Tab storage t = _tabs[tabId];
+
+        if (t.agent == address(0)) revert PayErrors.TabNotFound(tabId);
+        if (t.status != PayTypes.TabStatus.Active) revert PayErrors.TabClosed(tabId);
+        if (amount == 0) revert PayErrors.ZeroAmount();
+        if (amount > t.maxChargePerCall) revert PayErrors.ChargeLimitExceeded(tabId, amount, t.maxChargePerCall);
+        if (amount > t.amount) revert PayErrors.InsufficientBalance(tabId, amount, t.amount);
+
+        t.amount -= amount;
+        t.totalCharged += amount;
+        t.chargeCount += 1;
+
+        emit PayEvents.TabCharged(tabId, amount, t.amount, t.chargeCount);
+    }
+
+    // =========================================================================
+    // IPayTab — topUpTab
+    // =========================================================================
+
+    /// @inheritdoc IPayTab
+    function topUpTab(bytes32 tabId, uint96 amount) external nonReentrant {
+        _topUp(msg.sender, tabId, amount);
+    }
+
+    /// @inheritdoc IPayTab
+    function topUpTabFor(address agent, bytes32 tabId, uint96 amount) external nonReentrant onlyRelayer {
+        if (agent == address(0)) revert PayErrors.ZeroAddress();
+        _topUp(agent, tabId, amount);
+    }
+
+    // =========================================================================
+    // IPayTab — withdrawCharged (scheduled rectification only)
+    // =========================================================================
+
+    /// @inheritdoc IPayTab
+    /// @dev onlyRelayer (same as v3). Provider gets funds via closeTab or scheduled rectification.
+    ///      Fee: max(chargesNew * MIN_CHARGE_FEE, unwithdrawn * rateBps / 10_000), capped at unwithdrawn.
+    function withdrawCharged(bytes32 tabId) external nonReentrant onlyRelayer {
+        PayTypes.Tab storage t = _tabs[tabId];
+
+        if (t.agent == address(0)) revert PayErrors.TabNotFound(tabId);
+        if (t.status != PayTypes.TabStatus.Active) revert PayErrors.TabClosed(tabId);
+
+        uint96 unwithdrawn = t.totalCharged - t.totalWithdrawn;
+        if (unwithdrawn == 0) revert PayErrors.NothingToWithdraw(tabId);
+        if (unwithdrawn < PayTypes.MIN_WITHDRAW_AMOUNT) {
+            revert PayErrors.BelowMinimum(unwithdrawn, PayTypes.MIN_WITHDRAW_AMOUNT);
+        }
+
+        // Fee with per-charge floor: max(floor, rate-based)
+        uint96 fee = _calculateFeeWithFloor(t.provider, unwithdrawn, tabId, t.chargeCount);
+        uint96 payout = unwithdrawn - fee;
+
+        // --- Effects ---
+        t.totalWithdrawn += unwithdrawn;
+        _chargeCountAtLastWithdrawal[tabId] = t.chargeCount;
+        payFee.recordTransaction(t.provider, unwithdrawn);
+
+        // --- Interactions ---
+        if (payout > 0) {
+            bool sent = usdc.transfer(t.provider, payout);
+            if (!sent) revert PayErrors.TransferFailed();
+        }
+        if (fee > 0) {
+            bool sent = usdc.transfer(feeWallet, fee);
+            if (!sent) revert PayErrors.TransferFailed();
+        }
+
+        emit PayEvents.TabWithdrawn(tabId, payout, fee, t.totalWithdrawn);
+    }
+
+    // =========================================================================
+    // IPayTab — closeTab
+    // =========================================================================
+
+    /// @inheritdoc IPayTab
+    function closeTab(bytes32 tabId) external nonReentrant {
+        PayTypes.Tab storage t = _tabs[tabId];
+
+        if (t.agent == address(0)) revert PayErrors.TabNotFound(tabId);
+        if (t.status != PayTypes.TabStatus.Active) revert PayErrors.TabClosed(tabId);
+        if (msg.sender != t.agent && msg.sender != t.provider && msg.sender != relayer) {
+            revert PayErrors.Unauthorized(msg.sender);
+        }
+
+        address agent = t.agent;
+        address provider = t.provider;
+        uint96 totalCharged = t.totalCharged;
+        uint96 totalWithdrawn = t.totalWithdrawn;
+        uint96 remaining = t.amount;
+        uint256 chargeCount = t.chargeCount;
+
+        uint96 unwithdrawn = totalCharged - totalWithdrawn;
+        uint96 fee = 0;
+        uint96 providerPayout = 0;
+        if (unwithdrawn > 0) {
+            fee = _calculateFeeWithFloor(provider, unwithdrawn, tabId, chargeCount);
+            providerPayout = unwithdrawn - fee;
+        }
+
+        // --- Effects ---
+        t.status = PayTypes.TabStatus.Closed;
+        t.amount = 0;
+
+        if (unwithdrawn > 0) {
+            payFee.recordTransaction(provider, unwithdrawn);
+        }
+
+        // --- Interactions ---
+        if (providerPayout > 0) {
+            bool sent = usdc.transfer(provider, providerPayout);
+            if (!sent) revert PayErrors.TransferFailed();
+        }
+        if (fee > 0) {
+            bool sent = usdc.transfer(feeWallet, fee);
+            if (!sent) revert PayErrors.TransferFailed();
+        }
+        if (remaining > 0) {
+            bool sent = usdc.transfer(agent, remaining);
+            if (!sent) revert PayErrors.TransferFailed();
+        }
+
+        emit PayEvents.TabClosed(tabId, totalCharged, providerPayout, fee, remaining);
+    }
+
+    // =========================================================================
+    // IPayTab — getTab
+    // =========================================================================
+
+    /// @inheritdoc IPayTab
+    function getTab(bytes32 tabId) external view returns (PayTypes.Tab memory tab) {
+        tab = _tabs[tabId];
+        if (tab.agent == address(0)) revert PayErrors.TabNotFound(tabId);
+    }
+
+    // =========================================================================
+    // Internal
+    // =========================================================================
+
+    function _openTab(address agent, bytes32 tabId, address provider, uint96 amount, uint96 maxChargePerCall) internal {
+        if (provider == address(0)) revert PayErrors.ZeroAddress();
+        if (agent == provider) revert PayErrors.SelfPayment(agent);
+        if (amount < PayTypes.MIN_TAB_AMOUNT) revert PayErrors.BelowMinimum(amount, PayTypes.MIN_TAB_AMOUNT);
+        if (maxChargePerCall == 0) revert PayErrors.ZeroAmount();
+        if (_tabs[tabId].agent != address(0)) revert PayErrors.TabAlreadyExists(tabId);
+
+        uint96 activationFee = _calculateActivationFee(amount);
+        uint96 tabBalance = amount - activationFee;
+
+        _tabs[tabId] = PayTypes.Tab({
+            agent: agent,
+            amount: tabBalance,
+            provider: provider,
+            totalCharged: 0,
+            maxChargePerCall: maxChargePerCall,
+            activationFee: activationFee,
+            status: PayTypes.TabStatus.Active,
+            chargeCount: 0,
+            totalWithdrawn: 0
+        });
+
+        bool sent = usdc.transferFrom(agent, address(this), tabBalance);
+        if (!sent) revert PayErrors.TransferFailed();
+
+        sent = usdc.transferFrom(agent, feeWallet, activationFee);
+        if (!sent) revert PayErrors.TransferFailed();
+
+        emit PayEvents.TabOpened(tabId, agent, provider, tabBalance, maxChargePerCall, activationFee);
+    }
+
+    function _topUp(address caller, bytes32 tabId, uint96 amount) internal {
+        PayTypes.Tab storage t = _tabs[tabId];
+
+        if (t.agent == address(0)) revert PayErrors.TabNotFound(tabId);
+        if (t.status != PayTypes.TabStatus.Active) revert PayErrors.TabClosed(tabId);
+        if (amount == 0) revert PayErrors.ZeroAmount();
+        if (caller != t.agent) revert PayErrors.Unauthorized(caller);
+
+        t.amount += amount;
+
+        bool sent = usdc.transferFrom(caller, address(this), amount);
+        if (!sent) revert PayErrors.TransferFailed();
+
+        emit PayEvents.TabToppedUp(tabId, amount, t.amount);
+    }
+
+    /// @dev Activation fee: max(MIN_ACTIVATION_FEE, amount / 100).
+    function _calculateActivationFee(uint96 amount) internal pure returns (uint96) {
+        uint96 percentFee = amount / 100;
+        return percentFee > PayTypes.MIN_ACTIVATION_FEE ? percentFee : PayTypes.MIN_ACTIVATION_FEE;
+    }
+
+    /// @dev Fee with per-charge floor: max(chargesNew * MIN_CHARGE_FEE, unwithdrawn * rateBps / 10_000).
+    ///      Capped at unwithdrawn to prevent underflow when floor exceeds charged amount.
+    ///      This ensures micropayment tabs pay at least $0.002/charge, covering gas costs.
+    function _calculateFeeWithFloor(address provider, uint96 unwithdrawn, bytes32 tabId, uint256 chargeCount)
+        internal
+        view
+        returns (uint96)
+    {
+        uint96 rateBps = payFee.getFeeRate(provider);
+        uint96 rateFee = uint96((uint256(unwithdrawn) * rateBps) / 10_000);
+        uint256 chargesNew = chargeCount - _chargeCountAtLastWithdrawal[tabId];
+        uint96 floorFee = uint96(chargesNew * PayTypes.MIN_CHARGE_FEE);
+        uint96 fee = rateFee > floorFee ? rateFee : floorFee;
+        if (fee > unwithdrawn) fee = unwithdrawn;
+        return fee;
+    }
+}

--- a/test/PayTabV4.fuzz.t.sol
+++ b/test/PayTabV4.fuzz.t.sol
@@ -1,0 +1,302 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {Test} from "forge-std/Test.sol";
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+
+import {PayTabV4} from "../src/PayTabV4.sol";
+import {PayFee} from "../src/PayFee.sol";
+import {PayTypes} from "../src/libraries/PayTypes.sol";
+
+/// @title MockUSDCV4Fuzz
+contract MockUSDCV4Fuzz {
+    mapping(address => uint256) public balanceOf;
+    mapping(address => mapping(address => uint256)) public allowance;
+
+    function mint(address to, uint256 amount) external {
+        balanceOf[to] += amount;
+    }
+
+    function approve(address spender, uint256 amount) external returns (bool) {
+        allowance[msg.sender][spender] = amount;
+        return true;
+    }
+
+    function transfer(address to, uint256 amount) external returns (bool) {
+        if (balanceOf[msg.sender] < amount) return false;
+        balanceOf[msg.sender] -= amount;
+        balanceOf[to] += amount;
+        return true;
+    }
+
+    function transferFrom(address from, address to, uint256 amount) external returns (bool) {
+        if (balanceOf[from] < amount) return false;
+        if (allowance[from][msg.sender] < amount) return false;
+        balanceOf[from] -= amount;
+        balanceOf[to] += amount;
+        allowance[from][msg.sender] -= amount;
+        return true;
+    }
+
+    function permit(address, address, uint256, uint256, uint8, bytes32, bytes32) external pure {}
+}
+
+/// @title PayTabV4FuzzTest
+/// @notice Property-based fuzz tests for PayTabV4 fee floor enforcement.
+contract PayTabV4FuzzTest is Test {
+    PayTabV4 internal tab;
+    PayFee internal fee;
+    MockUSDCV4Fuzz internal usdc;
+
+    address internal owner = makeAddr("owner");
+    address internal relayerAddr = makeAddr("relayer");
+    address internal feeWallet = makeAddr("feeWallet");
+    address internal agent = makeAddr("agent");
+    address internal provider = makeAddr("provider");
+
+    uint96 constant STANDARD_BPS = PayTypes.FEE_RATE_BPS;
+    uint96 constant MIN_CHARGE_FEE = PayTypes.MIN_CHARGE_FEE;
+    uint96 constant MIN_TAB = PayTypes.MIN_TAB_AMOUNT;
+    uint96 constant MIN_WITHDRAW = PayTypes.MIN_WITHDRAW_AMOUNT;
+
+    function setUp() public {
+        usdc = new MockUSDCV4Fuzz();
+
+        PayFee feeImpl = new PayFee();
+        bytes memory data = abi.encodeCall(feeImpl.initialize, (owner));
+        fee = PayFee(address(new ERC1967Proxy(address(feeImpl), data)));
+
+        tab = new PayTabV4(address(usdc), address(fee), feeWallet, relayerAddr);
+
+        vm.prank(owner);
+        fee.authorizeCaller(address(tab));
+
+        usdc.mint(agent, type(uint96).max);
+        vm.prank(agent);
+        usdc.approve(address(tab), type(uint256).max);
+
+        vm.warp(1773532800);
+    }
+
+    // =========================================================================
+    // Property: fee >= max(floor, rate-based) AND fee <= unwithdrawn
+    // =========================================================================
+
+    function testFuzz_withdrawFeeFloorEnforced(uint96 tabAmount, uint8 numCharges, uint96 chargeSize) public {
+        tabAmount = uint96(bound(tabAmount, MIN_TAB, 500_000e6));
+        numCharges = uint8(bound(numCharges, 1, 100));
+
+        bytes32 tabId = bytes32("fuzz-floor");
+        vm.prank(agent);
+        tab.openTab(tabId, provider, tabAmount, tabAmount);
+
+        uint96 balance = tab.getTab(tabId).amount;
+        // Each charge must fit in balance / numCharges, and be at least 1
+        uint96 maxPerCharge = balance / uint96(numCharges);
+        if (maxPerCharge == 0) return;
+        chargeSize = uint96(bound(chargeSize, 1, maxPerCharge));
+
+        // Do the charges
+        vm.startPrank(relayerAddr);
+        for (uint256 i = 0; i < numCharges; i++) {
+            tab.chargeTab(tabId, chargeSize);
+        }
+        vm.stopPrank();
+
+        uint96 totalCharged = chargeSize * uint96(numCharges);
+        if (totalCharged < MIN_WITHDRAW) return; // skip if below withdraw min
+
+        uint256 feeWalletBefore = usdc.balanceOf(feeWallet);
+
+        vm.prank(relayerAddr);
+        tab.withdrawCharged(tabId);
+
+        uint256 feeCollected = usdc.balanceOf(feeWallet) - feeWalletBefore;
+
+        // Expected bounds
+        uint96 rateFee = uint96((uint256(totalCharged) * STANDARD_BPS) / 10_000);
+        uint96 floorFee = uint96(uint256(numCharges) * MIN_CHARGE_FEE);
+        uint96 expectedMin = rateFee > floorFee ? rateFee : floorFee;
+        if (expectedMin > totalCharged) expectedMin = totalCharged;
+
+        assertEq(feeCollected, expectedMin, "fee must equal max(floor, rate), capped at unwithdrawn");
+    }
+
+    // =========================================================================
+    // Property: USDC conservation through withdraw + close with floor
+    // =========================================================================
+
+    function testFuzz_withdrawThenClose_usdcConserved(uint96 tabAmount, uint8 numCharges, uint96 chargeSize) public {
+        tabAmount = uint96(bound(tabAmount, MIN_TAB, 500_000e6));
+        numCharges = uint8(bound(numCharges, 1, 50));
+
+        bytes32 tabId = bytes32("fuzz-conserve");
+        vm.prank(agent);
+        tab.openTab(tabId, provider, tabAmount, tabAmount);
+
+        uint96 balance = tab.getTab(tabId).amount;
+        uint96 maxPerCharge = balance / uint96(numCharges);
+        if (maxPerCharge == 0) return;
+        chargeSize = uint96(bound(chargeSize, 1, maxPerCharge));
+
+        vm.startPrank(relayerAddr);
+        for (uint256 i = 0; i < numCharges; i++) {
+            tab.chargeTab(tabId, chargeSize);
+        }
+        vm.stopPrank();
+
+        uint96 totalCharged = chargeSize * uint96(numCharges);
+
+        uint256 totalBefore =
+            usdc.balanceOf(agent) + usdc.balanceOf(provider) + usdc.balanceOf(feeWallet) + usdc.balanceOf(address(tab));
+
+        // Withdraw if possible
+        if (totalCharged >= MIN_WITHDRAW) {
+            vm.prank(relayerAddr);
+            tab.withdrawCharged(tabId);
+        }
+
+        // Close
+        vm.prank(agent);
+        tab.closeTab(tabId);
+
+        uint256 totalAfter =
+            usdc.balanceOf(agent) + usdc.balanceOf(provider) + usdc.balanceOf(feeWallet) + usdc.balanceOf(address(tab));
+
+        assertEq(totalAfter, totalBefore, "USDC must be conserved");
+        assertEq(usdc.balanceOf(address(tab)), 0, "contract empty after close");
+    }
+
+    // =========================================================================
+    // Property: distribution sums to tab balance
+    // =========================================================================
+
+    function testFuzz_close_distributionSumsToTabBalance(uint96 tabAmount, uint8 numCharges, uint96 chargeSize) public {
+        tabAmount = uint96(bound(tabAmount, MIN_TAB, 500_000e6));
+        numCharges = uint8(bound(numCharges, 1, 50));
+
+        bytes32 tabId = bytes32("fuzz-dist");
+        vm.prank(agent);
+        tab.openTab(tabId, provider, tabAmount, tabAmount);
+
+        uint96 balance = tab.getTab(tabId).amount;
+        uint96 maxPerCharge = balance / uint96(numCharges);
+        if (maxPerCharge == 0) return;
+        chargeSize = uint96(bound(chargeSize, 1, maxPerCharge));
+
+        vm.startPrank(relayerAddr);
+        for (uint256 i = 0; i < numCharges; i++) {
+            tab.chargeTab(tabId, chargeSize);
+        }
+        vm.stopPrank();
+
+        uint256 providerBefore = usdc.balanceOf(provider);
+        uint256 feeWalletBefore = usdc.balanceOf(feeWallet);
+        uint256 agentBefore = usdc.balanceOf(agent);
+
+        vm.prank(agent);
+        tab.closeTab(tabId);
+
+        uint256 providerGain = usdc.balanceOf(provider) - providerBefore;
+        uint256 feeGain = usdc.balanceOf(feeWallet) - feeWalletBefore;
+        uint256 agentGain = usdc.balanceOf(agent) - agentBefore;
+
+        assertEq(providerGain + feeGain + agentGain, balance, "distribution must sum to tab balance");
+    }
+
+    // =========================================================================
+    // Property: fee floor tracks correctly across multiple withdrawal windows
+    // =========================================================================
+
+    function testFuzz_multipleWithdrawals_floorTracksCorrectly(
+        uint8 chargesRound1,
+        uint8 chargesRound2,
+        uint96 chargeSize
+    ) public {
+        chargesRound1 = uint8(bound(chargesRound1, 1, 30));
+        chargesRound2 = uint8(bound(chargesRound2, 1, 30));
+        uint256 totalCharges = uint256(chargesRound1) + uint256(chargesRound2);
+
+        bytes32 tabId = bytes32("fuzz-multi");
+        uint96 tabAmount = 100e6; // $100
+        vm.prank(agent);
+        tab.openTab(tabId, provider, tabAmount, tabAmount);
+
+        uint96 balance = tab.getTab(tabId).amount;
+        uint96 maxPerCharge = balance / uint96(totalCharges);
+        if (maxPerCharge == 0) return;
+        chargeSize = uint96(bound(chargeSize, 1, maxPerCharge));
+
+        // Round 1
+        vm.startPrank(relayerAddr);
+        for (uint256 i = 0; i < chargesRound1; i++) {
+            tab.chargeTab(tabId, chargeSize);
+        }
+        vm.stopPrank();
+
+        uint96 charged1 = chargeSize * uint96(chargesRound1);
+        if (charged1 >= MIN_WITHDRAW) {
+            uint256 feeWalletBefore = usdc.balanceOf(feeWallet);
+
+            vm.prank(relayerAddr);
+            tab.withdrawCharged(tabId);
+
+            uint256 fee1 = usdc.balanceOf(feeWallet) - feeWalletBefore;
+            uint96 rateFee1 = uint96((uint256(charged1) * STANDARD_BPS) / 10_000);
+            uint96 floorFee1 = uint96(uint256(chargesRound1) * MIN_CHARGE_FEE);
+            uint96 expected1 = rateFee1 > floorFee1 ? rateFee1 : floorFee1;
+            if (expected1 > charged1) expected1 = charged1;
+            assertEq(fee1, expected1, "round 1 fee correct");
+        }
+
+        // Round 2
+        vm.startPrank(relayerAddr);
+        for (uint256 i = 0; i < chargesRound2; i++) {
+            tab.chargeTab(tabId, chargeSize);
+        }
+        vm.stopPrank();
+
+        // Close — fee should only count round 2 charges (or all if round 1 wasn't withdrawn)
+        vm.prank(agent);
+        tab.closeTab(tabId);
+
+        // Conservation check
+        assertEq(usdc.balanceOf(address(tab)), 0, "contract empty");
+    }
+
+    // =========================================================================
+    // Property: fee never exceeds unwithdrawn
+    // =========================================================================
+
+    function testFuzz_feeNeverExceedsUnwithdrawn(uint96 tabAmount, uint8 numCharges, uint96 chargeSize) public {
+        tabAmount = uint96(bound(tabAmount, MIN_TAB, 100_000e6));
+        numCharges = uint8(bound(numCharges, 1, 200));
+
+        bytes32 tabId = bytes32("fuzz-cap");
+        vm.prank(agent);
+        tab.openTab(tabId, provider, tabAmount, tabAmount);
+
+        uint96 balance = tab.getTab(tabId).amount;
+        uint96 maxPerCharge = balance / uint96(numCharges);
+        if (maxPerCharge == 0) return;
+        chargeSize = uint96(bound(chargeSize, 1, maxPerCharge));
+
+        vm.startPrank(relayerAddr);
+        for (uint256 i = 0; i < numCharges; i++) {
+            tab.chargeTab(tabId, chargeSize);
+        }
+        vm.stopPrank();
+
+        uint96 totalCharged = chargeSize * uint96(numCharges);
+
+        uint256 feeWalletBefore = usdc.balanceOf(feeWallet);
+
+        vm.prank(agent);
+        tab.closeTab(tabId);
+
+        uint256 feeCollected = usdc.balanceOf(feeWallet) - feeWalletBefore;
+
+        assertLe(feeCollected, totalCharged, "fee must not exceed total charged");
+        // Provider should never go negative (implied by no revert)
+    }
+}

--- a/test/PayTabV4.t.sol
+++ b/test/PayTabV4.t.sol
@@ -1,0 +1,448 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {Test} from "forge-std/Test.sol";
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+
+import {PayTabV4} from "../src/PayTabV4.sol";
+import {PayFee} from "../src/PayFee.sol";
+import {PayTypes} from "../src/libraries/PayTypes.sol";
+import {PayErrors} from "../src/libraries/PayErrors.sol";
+import {PayEvents} from "../src/libraries/PayEvents.sol";
+
+/// @title MockUSDCV4
+contract MockUSDCV4 {
+    mapping(address => uint256) public balanceOf;
+    mapping(address => mapping(address => uint256)) public allowance;
+
+    function mint(address to, uint256 amount) external {
+        balanceOf[to] += amount;
+    }
+
+    function approve(address spender, uint256 amount) external returns (bool) {
+        allowance[msg.sender][spender] = amount;
+        return true;
+    }
+
+    function transfer(address to, uint256 amount) external returns (bool) {
+        if (balanceOf[msg.sender] < amount) return false;
+        balanceOf[msg.sender] -= amount;
+        balanceOf[to] += amount;
+        return true;
+    }
+
+    function transferFrom(address from, address to, uint256 amount) external returns (bool) {
+        if (balanceOf[from] < amount) return false;
+        if (allowance[from][msg.sender] < amount) return false;
+        balanceOf[from] -= amount;
+        balanceOf[to] += amount;
+        allowance[from][msg.sender] -= amount;
+        return true;
+    }
+
+    function permit(address, address, uint256, uint256, uint8, bytes32, bytes32) external pure {}
+}
+
+/// @title PayTabV4Test
+/// @notice Unit tests for PayTabV4 fee floor enforcement.
+contract PayTabV4Test is Test {
+    PayTabV4 internal tab;
+    PayFee internal fee;
+    MockUSDCV4 internal usdc;
+
+    address internal owner = makeAddr("owner");
+    address internal relayerAddr = makeAddr("relayer");
+    address internal feeWallet = makeAddr("feeWallet");
+    address internal agent = makeAddr("agent");
+    address internal provider = makeAddr("provider");
+
+    bytes32 constant TAB_ID = bytes32("tab-v4-001");
+    uint96 constant TAB_AMOUNT = 100e6; // $100
+    uint96 constant MAX_CHARGE = 50e6;
+
+    uint96 constant STANDARD_BPS = PayTypes.FEE_RATE_BPS; // 100 = 1%
+    uint96 constant MIN_CHARGE_FEE = PayTypes.MIN_CHARGE_FEE; // 2_000 = $0.002
+
+    uint96 internal tabBalance;
+
+    function setUp() public {
+        usdc = new MockUSDCV4();
+
+        PayFee feeImpl = new PayFee();
+        bytes memory data = abi.encodeCall(feeImpl.initialize, (owner));
+        fee = PayFee(address(new ERC1967Proxy(address(feeImpl), data)));
+
+        tab = new PayTabV4(address(usdc), address(fee), feeWallet, relayerAddr);
+
+        vm.prank(owner);
+        fee.authorizeCaller(address(tab));
+
+        usdc.mint(agent, 1_000_000e6);
+        vm.prank(agent);
+        usdc.approve(address(tab), type(uint256).max);
+
+        vm.prank(agent);
+        tab.openTab(TAB_ID, provider, TAB_AMOUNT, MAX_CHARGE);
+        tabBalance = tab.getTab(TAB_ID).amount;
+
+        vm.warp(1773532800);
+    }
+
+    // =========================================================================
+    // Fee floor: many small charges trigger floor
+    // =========================================================================
+
+    function test_feeFloor_manySmallCharges_withdrawCharged() public {
+        // 50 charges of $0.01 each = $0.50 total
+        // 1% of $0.50 = $0.005 (5_000)
+        // Floor: 50 * $0.002 = $0.10 (100_000)
+        // Floor wins: fee should be $0.10
+        vm.startPrank(relayerAddr);
+        for (uint256 i = 0; i < 50; i++) {
+            tab.chargeTab(TAB_ID, 10_000); // $0.01
+        }
+        vm.stopPrank();
+
+        uint96 unwithdrawn = 500_000; // $0.50
+        uint96 expectedFloorFee = 50 * MIN_CHARGE_FEE; // $0.10
+        uint96 expectedRateFee = uint96((uint256(unwithdrawn) * STANDARD_BPS) / 10_000); // $0.005
+
+        // Floor must be higher
+        assertGt(expectedFloorFee, expectedRateFee, "floor should exceed rate fee");
+
+        uint256 feeWalletBefore = usdc.balanceOf(feeWallet);
+
+        vm.prank(relayerAddr);
+        tab.withdrawCharged(TAB_ID);
+
+        uint256 feeCollected = usdc.balanceOf(feeWallet) - feeWalletBefore;
+        assertEq(feeCollected, expectedFloorFee, "fee must equal floor fee");
+
+        // Provider gets remainder
+        uint96 expectedPayout = unwithdrawn - expectedFloorFee;
+        assertEq(usdc.balanceOf(provider), expectedPayout);
+    }
+
+    function test_feeFloor_manySmallCharges_closeTab() public {
+        // Same scenario but via closeTab
+        vm.startPrank(relayerAddr);
+        for (uint256 i = 0; i < 50; i++) {
+            tab.chargeTab(TAB_ID, 10_000);
+        }
+        vm.stopPrank();
+
+        uint96 unwithdrawn = 500_000;
+        uint96 expectedFloorFee = 50 * MIN_CHARGE_FEE;
+
+        uint256 feeWalletBefore = usdc.balanceOf(feeWallet);
+
+        vm.prank(agent);
+        tab.closeTab(TAB_ID);
+
+        uint256 feeCollected = usdc.balanceOf(feeWallet) - feeWalletBefore;
+        assertEq(feeCollected, expectedFloorFee, "close fee must equal floor fee");
+    }
+
+    // =========================================================================
+    // Fee floor: large charges — rate wins over floor
+    // =========================================================================
+
+    function test_feeFloor_largeCharges_rateWins() public {
+        // 3 charges of $10 each = $30 total
+        // 1% of $30 = $0.30 (300_000)
+        // Floor: 3 * $0.002 = $0.006 (6_000)
+        // Rate wins: fee should be $0.30
+        vm.startPrank(relayerAddr);
+        tab.chargeTab(TAB_ID, 10e6);
+        tab.chargeTab(TAB_ID, 10e6);
+        tab.chargeTab(TAB_ID, 10e6);
+        vm.stopPrank();
+
+        uint96 unwithdrawn = 30e6;
+        uint96 expectedRateFee = uint96((uint256(unwithdrawn) * STANDARD_BPS) / 10_000);
+        uint96 expectedFloorFee = 3 * MIN_CHARGE_FEE;
+
+        assertGt(expectedRateFee, expectedFloorFee, "rate should exceed floor");
+
+        uint256 feeWalletBefore = usdc.balanceOf(feeWallet);
+
+        vm.prank(relayerAddr);
+        tab.withdrawCharged(TAB_ID);
+
+        uint256 feeCollected = usdc.balanceOf(feeWallet) - feeWalletBefore;
+        assertEq(feeCollected, expectedRateFee, "fee must equal rate fee when rate > floor");
+    }
+
+    // =========================================================================
+    // Fee floor: exactly at boundary ($0.20/charge = 1% equals floor)
+    // =========================================================================
+
+    function test_feeFloor_exactBoundary() public {
+        // At $0.20/charge: 1% = $0.002 = MIN_CHARGE_FEE. Both equal.
+        // 10 charges of $0.20 = $2.00
+        // 1% of $2.00 = $0.02 (20_000)
+        // Floor: 10 * $0.002 = $0.02 (20_000)
+        // Equal — either path produces same fee
+        vm.startPrank(relayerAddr);
+        for (uint256 i = 0; i < 10; i++) {
+            tab.chargeTab(TAB_ID, 200_000); // $0.20
+        }
+        vm.stopPrank();
+
+        uint96 unwithdrawn = 2_000_000;
+        uint96 expectedFee = 10 * MIN_CHARGE_FEE; // same as 1% of $2.00
+
+        uint256 feeWalletBefore = usdc.balanceOf(feeWallet);
+
+        vm.prank(relayerAddr);
+        tab.withdrawCharged(TAB_ID);
+
+        uint256 feeCollected = usdc.balanceOf(feeWallet) - feeWalletBefore;
+        assertEq(feeCollected, expectedFee);
+    }
+
+    // =========================================================================
+    // Fee floor capped at unwithdrawn (extreme micropayments)
+    // =========================================================================
+
+    function test_feeFloor_cappedAtUnwithdrawn() public {
+        // 100 charges of $0.001 each = $0.10 total
+        // 1% of $0.10 = $0.001 (1_000)
+        // Floor: 100 * $0.002 = $0.20 (200_000)
+        // Floor exceeds unwithdrawn ($0.10)! Cap at $0.10.
+        // Provider gets $0, fee wallet gets entire $0.10.
+        vm.startPrank(relayerAddr);
+        for (uint256 i = 0; i < 100; i++) {
+            tab.chargeTab(TAB_ID, 1_000); // $0.001
+        }
+        vm.stopPrank();
+
+        uint96 unwithdrawn = 100_000; // $0.10 (exactly MIN_WITHDRAW_AMOUNT)
+        uint96 floorFee = 100 * MIN_CHARGE_FEE; // $0.20
+        assertGt(floorFee, unwithdrawn, "floor exceeds unwithdrawn — cap should kick in");
+
+        uint256 feeWalletBefore = usdc.balanceOf(feeWallet);
+
+        vm.prank(relayerAddr);
+        tab.withdrawCharged(TAB_ID);
+
+        uint256 feeCollected = usdc.balanceOf(feeWallet) - feeWalletBefore;
+        assertEq(feeCollected, unwithdrawn, "fee capped at unwithdrawn");
+
+        // Provider gets nothing (fee ate everything)
+        assertEq(usdc.balanceOf(provider), 0, "provider gets 0 when floor > unwithdrawn");
+    }
+
+    // =========================================================================
+    // chargeCountAtLastWithdrawal tracks across multiple withdrawals
+    // =========================================================================
+
+    function test_feeFloor_multipleWithdrawals_chargeCountTracked() public {
+        // Round 1: 20 charges of $0.05 = $1.00
+        // Floor: 20 * $0.002 = $0.04, Rate: 1% of $1.00 = $0.01 → floor wins
+        vm.startPrank(relayerAddr);
+        for (uint256 i = 0; i < 20; i++) {
+            tab.chargeTab(TAB_ID, 50_000); // $0.05
+        }
+        vm.stopPrank();
+
+        uint256 feeWalletBefore = usdc.balanceOf(feeWallet);
+
+        vm.prank(relayerAddr);
+        tab.withdrawCharged(TAB_ID);
+
+        uint96 expectedFee1 = 20 * MIN_CHARGE_FEE; // $0.04
+        uint256 fee1 = usdc.balanceOf(feeWallet) - feeWalletBefore;
+        assertEq(fee1, expectedFee1, "first withdrawal: floor fee");
+
+        // Round 2: 10 more charges of $0.05 = $0.50
+        // Floor: 10 * $0.002 = $0.02, Rate: 1% of $0.50 = $0.005 → floor wins
+        vm.startPrank(relayerAddr);
+        for (uint256 i = 0; i < 10; i++) {
+            tab.chargeTab(TAB_ID, 50_000);
+        }
+        vm.stopPrank();
+
+        feeWalletBefore = usdc.balanceOf(feeWallet);
+
+        vm.prank(relayerAddr);
+        tab.withdrawCharged(TAB_ID);
+
+        uint96 expectedFee2 = 10 * MIN_CHARGE_FEE; // $0.02 (NOT 30 * $0.002)
+        uint256 fee2 = usdc.balanceOf(feeWallet) - feeWalletBefore;
+        assertEq(fee2, expectedFee2, "second withdrawal: floor uses only new charges");
+    }
+
+    // =========================================================================
+    // closeTab after withdrawal uses correct chargesNew delta
+    // =========================================================================
+
+    function test_feeFloor_closeAfterWithdrawal_correctDelta() public {
+        // Withdraw after 20 small charges, then 5 more, then close
+        vm.startPrank(relayerAddr);
+        for (uint256 i = 0; i < 20; i++) {
+            tab.chargeTab(TAB_ID, 10_000); // $0.01
+        }
+        vm.stopPrank();
+
+        vm.prank(relayerAddr);
+        tab.withdrawCharged(TAB_ID); // withdraws $0.20, floor = 20 * $0.002 = $0.04
+
+        // 5 more charges
+        vm.startPrank(relayerAddr);
+        for (uint256 i = 0; i < 5; i++) {
+            tab.chargeTab(TAB_ID, 10_000);
+        }
+        vm.stopPrank();
+
+        uint256 feeWalletBefore = usdc.balanceOf(feeWallet);
+
+        vm.prank(agent);
+        tab.closeTab(TAB_ID);
+
+        // Close should only apply floor for 5 new charges, not 25 total
+        // unwithdrawn at close = $0.05, floor = 5 * $0.002 = $0.01, rate = 1% of $0.05 = $0.0005
+        uint96 expectedCloseFee = 5 * MIN_CHARGE_FEE; // $0.01
+        uint256 closeFee = usdc.balanceOf(feeWallet) - feeWalletBefore;
+        assertEq(closeFee, expectedCloseFee, "close fee uses delta charges only");
+    }
+
+    // =========================================================================
+    // settleCharges works the same as V3
+    // =========================================================================
+
+    function test_settleCharges_worksWithFeeFloor() public {
+        // Use batch settlement, then withdraw with floor
+        vm.prank(relayerAddr);
+        tab.settleCharges(TAB_ID, 500_000, 50, 10_000); // $0.50, 50 charges, max $0.01
+
+        uint96 unwithdrawn = 500_000;
+        uint96 expectedFloorFee = 50 * MIN_CHARGE_FEE; // $0.10
+
+        uint256 feeWalletBefore = usdc.balanceOf(feeWallet);
+
+        vm.prank(relayerAddr);
+        tab.withdrawCharged(TAB_ID);
+
+        uint256 feeCollected = usdc.balanceOf(feeWallet) - feeWalletBefore;
+        assertEq(feeCollected, expectedFloorFee, "settle + withdraw: floor applied");
+    }
+
+    // =========================================================================
+    // USDC conservation through full V4 lifecycle
+    // =========================================================================
+
+    function test_feeFloor_usdcConserved_fullLifecycle() public {
+        // Charge, withdraw, charge more, close — all USDC accounted for
+        vm.startPrank(relayerAddr);
+        for (uint256 i = 0; i < 30; i++) {
+            tab.chargeTab(TAB_ID, 10_000); // $0.01 each
+        }
+        vm.stopPrank();
+
+        uint256 totalBefore =
+            usdc.balanceOf(agent) + usdc.balanceOf(provider) + usdc.balanceOf(feeWallet) + usdc.balanceOf(address(tab));
+
+        vm.prank(relayerAddr);
+        tab.withdrawCharged(TAB_ID);
+
+        // 20 more charges
+        vm.startPrank(relayerAddr);
+        for (uint256 i = 0; i < 20; i++) {
+            tab.chargeTab(TAB_ID, 10_000);
+        }
+        vm.stopPrank();
+
+        vm.prank(agent);
+        tab.closeTab(TAB_ID);
+
+        uint256 totalAfter =
+            usdc.balanceOf(agent) + usdc.balanceOf(provider) + usdc.balanceOf(feeWallet) + usdc.balanceOf(address(tab));
+
+        assertEq(totalAfter, totalBefore, "USDC conserved through withdraw + close with floor");
+        assertEq(usdc.balanceOf(address(tab)), 0, "contract empty after close");
+    }
+
+    // =========================================================================
+    // V3 compatibility: basic withdraw/close still work
+    // =========================================================================
+
+    function test_basicWithdraw_sameAsV3() public {
+        // Standard large charges — V4 should behave identically to V3
+        vm.startPrank(relayerAddr);
+        tab.chargeTab(TAB_ID, 10e6);
+        tab.chargeTab(TAB_ID, 10e6);
+        tab.chargeTab(TAB_ID, 10e6);
+        vm.stopPrank();
+
+        uint96 charged = 30e6;
+        uint96 expectedFee = uint96((uint256(charged) * STANDARD_BPS) / 10_000);
+        uint96 expectedPayout = charged - expectedFee;
+
+        vm.prank(relayerAddr);
+        tab.withdrawCharged(TAB_ID);
+
+        assertEq(usdc.balanceOf(provider), expectedPayout);
+    }
+
+    function test_basicClose_sameAsV3() public {
+        vm.prank(relayerAddr);
+        tab.chargeTab(TAB_ID, 30e6);
+
+        uint96 charged = 30e6;
+        uint96 expectedFee = uint96((uint256(charged) * STANDARD_BPS) / 10_000);
+
+        uint256 feeWalletBefore = usdc.balanceOf(feeWallet);
+        uint256 providerBefore = usdc.balanceOf(provider);
+        uint256 agentBefore = usdc.balanceOf(agent);
+
+        vm.prank(agent);
+        tab.closeTab(TAB_ID);
+
+        uint256 providerGain = usdc.balanceOf(provider) - providerBefore;
+        uint256 feeGain = usdc.balanceOf(feeWallet) - feeWalletBefore;
+        uint256 agentGain = usdc.balanceOf(agent) - agentBefore;
+
+        assertEq(feeGain, expectedFee);
+        assertEq(providerGain, charged - expectedFee);
+        assertEq(providerGain + feeGain + agentGain, tabBalance, "distribution sums to tab balance");
+    }
+
+    // =========================================================================
+    // Access control unchanged from V3
+    // =========================================================================
+
+    function test_withdrawCharged_onlyRelayer() public {
+        vm.prank(relayerAddr);
+        tab.chargeTab(TAB_ID, 5e6);
+
+        vm.expectRevert(abi.encodeWithSelector(PayErrors.Unauthorized.selector, provider));
+        vm.prank(provider);
+        tab.withdrawCharged(TAB_ID);
+    }
+
+    function test_closeTab_anyParty() public {
+        vm.prank(relayerAddr);
+        tab.chargeTab(TAB_ID, 1e6);
+
+        // Agent can close
+        vm.prank(agent);
+        tab.closeTab(TAB_ID);
+
+        assertEq(uint8(tab.getTab(TAB_ID).status), uint8(PayTypes.TabStatus.Closed));
+    }
+
+    // =========================================================================
+    // MIN_WITHDRAW_AMOUNT = $0.10 (from V3)
+    // =========================================================================
+
+    function test_withdrawCharged_belowMinimum() public {
+        // Charge $0.05 — below $0.10 minimum
+        vm.prank(relayerAddr);
+        tab.chargeTab(TAB_ID, 50_000);
+
+        vm.expectRevert(abi.encodeWithSelector(PayErrors.BelowMinimum.selector, 50_000, PayTypes.MIN_WITHDRAW_AMOUNT));
+        vm.prank(relayerAddr);
+        tab.withdrawCharged(TAB_ID);
+    }
+}

--- a/test/PayTabV4.t.sol
+++ b/test/PayTabV4.t.sol
@@ -219,7 +219,7 @@ contract PayTabV4Test is Test {
 
         uint96 unwithdrawn = 100_000; // $0.10 (exactly MIN_WITHDRAW_AMOUNT)
         uint96 floorFee = 100 * MIN_CHARGE_FEE; // $0.20
-        assertGt(floorFee, unwithdrawn, "floor exceeds unwithdrawn — cap should kick in");
+        assertGt(floorFee, unwithdrawn, "floor exceeds unwithdrawn - cap should kick in");
 
         uint256 feeWalletBefore = usdc.balanceOf(feeWallet);
 


### PR DESCRIPTION
## Summary
- PayTabV3 calculates fees as pure 1% with no floor, despite spec requiring `max($0.002, 1%)` per charge
- Micropayment tabs collect far less in fees than gas costs for settlement/rectification
- PayTabV4 adds `_calculateFeeWithFloor`: `max(chargesNew * MIN_CHARGE_FEE, unwithdrawn * rateBps / 10_000)`
- New `_chargeCountAtLastWithdrawal` mapping tracks charges per withdrawal window
- Fee capped at unwithdrawn amount to prevent underflow on extreme micropayments

## Test plan
- [ ] Unit tests: fee floor applied on small charges, rate wins on large charges
- [ ] Unit tests: boundary case ($0.20/charge where floor == rate)
- [ ] Unit tests: fee capped when floor exceeds unwithdrawn
- [ ] Unit tests: chargeCountAtLastWithdrawal tracked across multiple withdrawals
- [ ] Unit tests: closeTab after withdrawal uses correct delta
- [ ] Unit tests: settleCharges + withdraw with floor
- [ ] Fuzz tests: fee == max(floor, rate) capped at unwithdrawn
- [ ] Fuzz tests: USDC conservation through withdraw + close
- [ ] Fuzz tests: distribution sums to tab balance
- [ ] Fuzz tests: multi-withdrawal floor tracking
- [ ] Fuzz tests: fee never exceeds unwithdrawn