### PR TITLE
PayTabV5: gas-optimized tab contract (P22)

### DIFF
--- a/script/DeployTabV5Testnet.s.sol
+++ b/script/DeployTabV5Testnet.s.sol
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {Script, console2} from "forge-std/Script.sol";
+
+import {PayFee} from "../src/PayFee.sol";
+import {PayTabV5} from "../src/PayTabV5.sol";
+
+/// @title DeployTabV5Testnet
+/// @notice Deploy ONLY PayTabV5 on Base Sepolia against existing infrastructure.
+///         Reads existing contract addresses from environment.
+///
+/// @dev Prerequisites:
+///      - DEPLOYER_PRIVATE_KEY: same deployer as original deploy
+///      - ALCHEMY_BASE_SEPOLIA_URL: Base Sepolia RPC
+///      - PAY_FEE_ADDRESS: existing PayFee proxy address
+///      - USDC_ADDRESS: existing MockUSDC address
+///      - FEE_WALLET: existing fee wallet (defaults to deployer)
+///
+///      Changes from V4:
+///        - Fee accumulation: activation + processing fees stored in contract,
+///          swept via sweepFees() to feeWallet.
+///        - ReentrancyGuardTransient: EIP-1153 TSTORE/TLOAD.
+///        - Packed struct: 4 slots (chargeCount uint32, chargeCountAtLastWithdraw merged).
+contract DeployTabV5Testnet is Script {
+    function run() external {
+        address deployer = msg.sender;
+
+        // Read existing addresses from env
+        address usdc = vm.envAddress("USDC_ADDRESS");
+        address payFeeProxy = vm.envAddress("PAY_FEE_ADDRESS");
+        address feeWallet = vm.envOr("FEE_WALLET", deployer);
+
+        console2.log("=== PayTabV5 Deployment (Base Sepolia) ===");
+        console2.log("Deployer:       ", deployer);
+        console2.log("USDC:           ", usdc);
+        console2.log("PayFee (proxy): ", payFeeProxy);
+        console2.log("Fee Wallet:     ", feeWallet);
+        console2.log("");
+
+        vm.startBroadcast();
+
+        // Deploy PayTabV5 (immutable)
+        PayTabV5 tabV5 = new PayTabV5(usdc, payFeeProxy, feeWallet, deployer);
+        console2.log("PayTabV5:       ", address(tabV5));
+
+        // Authorize PayTabV5 to call recordTransaction on PayFee
+        PayFee(payFeeProxy).authorizeCaller(address(tabV5));
+        console2.log("PayFee: authorized PayTabV5");
+
+        vm.stopBroadcast();
+
+        console2.log("");
+        console2.log("=== Done ===");
+        console2.log("Update server .env:");
+        console2.log("TAB_V2_ADDRESS=", address(tabV5));
+    }
+}

--- a/src/PayTabV5.sol
+++ b/src/PayTabV5.sol
@@ -1,0 +1,370 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {ReentrancyGuardTransient} from "@openzeppelin/contracts/utils/ReentrancyGuardTransient.sol";
+
+import {IPayTab} from "./interfaces/IPayTab.sol";
+import {IPayTabV2} from "./interfaces/IPayTabV2.sol";
+import {IPayFee} from "./interfaces/IPayFee.sol";
+import {IUSDC} from "./interfaces/IUSDC.sol";
+import {PayTypes} from "./libraries/PayTypes.sol";
+import {PayErrors} from "./libraries/PayErrors.sol";
+import {PayEvents} from "./libraries/PayEvents.sol";
+
+/// @title PayTabV5
+/// @notice Pre-funded metered account — gas-optimized via fee accumulation,
+///         transient reentrancy guard, and 4-slot struct packing.
+/// @dev IMMUTABLE -- no proxy, no admin key, no upgrade path. Holds USDC.
+///
+///      Changes from V4:
+///        - Fee accumulation: fees stored in _accumulatedFees, swept via sweepFees().
+///          Eliminates one USDC transfer per withdrawCharged/closeTab/openTab.
+///        - ReentrancyGuardTransient: TSTORE/TLOAD (100 gas) vs SSTORE/SLOAD (5000 gas).
+///        - TabV5 struct: 4 slots (chargeCount uint32, chargeCountAtLastWithdraw merged in).
+///          Eliminates separate _chargeCountAtLastWithdrawal mapping.
+///
+///      State machine (unchanged):
+///        nonexistent -> active (via openTab)
+///        active -> active (via chargeTab, settleCharges, topUpTab, withdrawCharged)
+///        active -> closed (via closeTab)
+contract PayTabV5 is IPayTabV2, ReentrancyGuardTransient {
+    // =========================================================================
+    // Immutable state
+    // =========================================================================
+
+    IUSDC public immutable usdc;
+    IPayFee public immutable payFee;
+    address public immutable feeWallet;
+    address public immutable relayer;
+
+    // =========================================================================
+    // Storage
+    // =========================================================================
+
+    /// @notice Tab storage. tabId -> TabV5 struct (4 slots per tab).
+    mapping(bytes32 => PayTypes.TabV5) internal _tabs;
+
+    /// @notice Accumulated fees pending sweep to feeWallet.
+    uint96 internal _accumulatedFees;
+
+    // =========================================================================
+    // Constructor
+    // =========================================================================
+
+    constructor(address usdc_, address payFee_, address feeWallet_, address relayer_) {
+        if (usdc_ == address(0)) revert PayErrors.ZeroAddress();
+        if (payFee_ == address(0)) revert PayErrors.ZeroAddress();
+        if (feeWallet_ == address(0)) revert PayErrors.ZeroAddress();
+        if (relayer_ == address(0)) revert PayErrors.ZeroAddress();
+
+        usdc = IUSDC(usdc_);
+        payFee = IPayFee(payFee_);
+        feeWallet = feeWallet_;
+        relayer = relayer_;
+    }
+
+    // =========================================================================
+    // Modifiers
+    // =========================================================================
+
+    modifier onlyRelayer() {
+        if (msg.sender != relayer) revert PayErrors.Unauthorized(msg.sender);
+        _;
+    }
+
+    // =========================================================================
+    // sweepFees -- batch transfer accumulated fees to feeWallet
+    // =========================================================================
+
+    /// @notice Transfer all accumulated fees to feeWallet in one USDC transfer.
+    /// @dev Permissionless -- funds always go to the immutable feeWallet.
+    function sweepFees() external nonReentrant {
+        uint96 fees = _accumulatedFees;
+        if (fees == 0) revert PayErrors.ZeroAmount();
+
+        _accumulatedFees = 0;
+
+        bool sent = usdc.transfer(feeWallet, fees);
+        if (!sent) revert PayErrors.TransferFailed();
+
+        emit PayEvents.FeeSwept(fees);
+    }
+
+    /// @notice Current accumulated fees pending sweep.
+    function accumulatedFees() external view returns (uint96) {
+        return _accumulatedFees;
+    }
+
+    // =========================================================================
+    // settleCharges -- batch SSTORE (from V2)
+    // =========================================================================
+
+    /// @inheritdoc IPayTabV2
+    function settleCharges(bytes32 tabId, uint96 totalAmount, uint32 chargeCount, uint96 maxSingleCharge)
+        external
+        onlyRelayer
+    {
+        PayTypes.TabV5 storage t = _tabs[tabId];
+
+        if (t.agent == address(0)) revert PayErrors.TabNotFound(tabId);
+        if (t.status != PayTypes.TabStatus.Active) revert PayErrors.TabClosed(tabId);
+        if (totalAmount == 0) revert PayErrors.ZeroAmount();
+        if (totalAmount > t.amount) revert PayErrors.InsufficientBalance(tabId, totalAmount, t.amount);
+        if (maxSingleCharge > t.maxChargePerCall) {
+            revert PayErrors.ChargeLimitExceeded(tabId, maxSingleCharge, t.maxChargePerCall);
+        }
+
+        t.amount -= totalAmount;
+        t.totalCharged += totalAmount;
+        t.chargeCount += chargeCount;
+
+        emit PayEvents.TabSettled(tabId, totalAmount, chargeCount, maxSingleCharge, t.amount, t.chargeCount);
+    }
+
+    // =========================================================================
+    // openTab
+    // =========================================================================
+
+    /// @inheritdoc IPayTab
+    function openTab(bytes32 tabId, address provider, uint96 amount, uint96 maxChargePerCall) external nonReentrant {
+        _openTab(msg.sender, tabId, provider, amount, maxChargePerCall);
+    }
+
+    /// @inheritdoc IPayTab
+    function openTabFor(address agent, bytes32 tabId, address provider, uint96 amount, uint96 maxChargePerCall)
+        external
+        nonReentrant
+        onlyRelayer
+    {
+        if (agent == address(0)) revert PayErrors.ZeroAddress();
+        _openTab(agent, tabId, provider, amount, maxChargePerCall);
+    }
+
+    // =========================================================================
+    // chargeTab
+    // =========================================================================
+
+    /// @inheritdoc IPayTab
+    function chargeTab(bytes32 tabId, uint96 amount) external onlyRelayer {
+        PayTypes.TabV5 storage t = _tabs[tabId];
+
+        if (t.agent == address(0)) revert PayErrors.TabNotFound(tabId);
+        if (t.status != PayTypes.TabStatus.Active) revert PayErrors.TabClosed(tabId);
+        if (amount == 0) revert PayErrors.ZeroAmount();
+        if (amount > t.maxChargePerCall) revert PayErrors.ChargeLimitExceeded(tabId, amount, t.maxChargePerCall);
+        if (amount > t.amount) revert PayErrors.InsufficientBalance(tabId, amount, t.amount);
+
+        t.amount -= amount;
+        t.totalCharged += amount;
+        t.chargeCount += 1;
+
+        emit PayEvents.TabCharged(tabId, amount, t.amount, t.chargeCount);
+    }
+
+    // =========================================================================
+    // topUpTab
+    // =========================================================================
+
+    /// @inheritdoc IPayTab
+    function topUpTab(bytes32 tabId, uint96 amount) external nonReentrant {
+        _topUp(msg.sender, tabId, amount);
+    }
+
+    /// @inheritdoc IPayTab
+    function topUpTabFor(address agent, bytes32 tabId, uint96 amount) external nonReentrant onlyRelayer {
+        if (agent == address(0)) revert PayErrors.ZeroAddress();
+        _topUp(agent, tabId, amount);
+    }
+
+    // =========================================================================
+    // withdrawCharged
+    // =========================================================================
+
+    /// @inheritdoc IPayTab
+    /// @dev onlyRelayer. Fee accumulated (not transferred). One USDC transfer (provider payout).
+    function withdrawCharged(bytes32 tabId) external nonReentrant onlyRelayer {
+        PayTypes.TabV5 storage t = _tabs[tabId];
+
+        if (t.agent == address(0)) revert PayErrors.TabNotFound(tabId);
+        if (t.status != PayTypes.TabStatus.Active) revert PayErrors.TabClosed(tabId);
+
+        uint96 unwithdrawn = t.totalCharged - t.totalWithdrawn;
+        if (unwithdrawn == 0) revert PayErrors.NothingToWithdraw(tabId);
+        if (unwithdrawn < PayTypes.MIN_WITHDRAW_AMOUNT) {
+            revert PayErrors.BelowMinimum(unwithdrawn, PayTypes.MIN_WITHDRAW_AMOUNT);
+        }
+
+        uint96 fee = _calculateFeeWithFloor(t.provider, unwithdrawn, t.chargeCount, t.chargeCountAtLastWithdraw);
+        uint96 payout = unwithdrawn - fee;
+
+        // --- Effects ---
+        t.totalWithdrawn += unwithdrawn;
+        t.chargeCountAtLastWithdraw = t.chargeCount;
+        _accumulatedFees += fee;
+        payFee.recordTransaction(t.provider, unwithdrawn);
+
+        // --- Interactions ---
+        if (payout > 0) {
+            bool sent = usdc.transfer(t.provider, payout);
+            if (!sent) revert PayErrors.TransferFailed();
+        }
+
+        emit PayEvents.TabWithdrawn(tabId, payout, fee, t.totalWithdrawn);
+    }
+
+    // =========================================================================
+    // closeTab
+    // =========================================================================
+
+    /// @inheritdoc IPayTab
+    function closeTab(bytes32 tabId) external nonReentrant {
+        PayTypes.TabV5 storage t = _tabs[tabId];
+
+        if (t.agent == address(0)) revert PayErrors.TabNotFound(tabId);
+        if (t.status != PayTypes.TabStatus.Active) revert PayErrors.TabClosed(tabId);
+        if (msg.sender != t.agent && msg.sender != t.provider && msg.sender != relayer) {
+            revert PayErrors.Unauthorized(msg.sender);
+        }
+
+        address agent = t.agent;
+        address provider = t.provider;
+        uint96 totalCharged = t.totalCharged;
+        uint96 totalWithdrawn = t.totalWithdrawn;
+        uint96 remaining = t.amount;
+        uint32 chargeCount = t.chargeCount;
+        uint32 chargeCountAtLastWithdraw = t.chargeCountAtLastWithdraw;
+
+        uint96 unwithdrawn = totalCharged - totalWithdrawn;
+        uint96 fee = 0;
+        uint96 providerPayout = 0;
+        if (unwithdrawn > 0) {
+            fee = _calculateFeeWithFloor(provider, unwithdrawn, chargeCount, chargeCountAtLastWithdraw);
+            providerPayout = unwithdrawn - fee;
+        }
+
+        // --- Effects ---
+        t.status = PayTypes.TabStatus.Closed;
+        t.amount = 0;
+
+        if (fee > 0) {
+            _accumulatedFees += fee;
+        }
+        if (unwithdrawn > 0) {
+            payFee.recordTransaction(provider, unwithdrawn);
+        }
+
+        // --- Interactions ---
+        if (providerPayout > 0) {
+            bool sent = usdc.transfer(provider, providerPayout);
+            if (!sent) revert PayErrors.TransferFailed();
+        }
+        if (remaining > 0) {
+            bool sent = usdc.transfer(agent, remaining);
+            if (!sent) revert PayErrors.TransferFailed();
+        }
+
+        emit PayEvents.TabClosed(tabId, totalCharged, providerPayout, fee, remaining);
+    }
+
+    // =========================================================================
+    // getTab — returns V4-compatible Tab struct for interface compliance
+    // =========================================================================
+
+    /// @inheritdoc IPayTab
+    function getTab(bytes32 tabId) external view returns (PayTypes.Tab memory tab) {
+        PayTypes.TabV5 storage t = _tabs[tabId];
+        if (t.agent == address(0)) revert PayErrors.TabNotFound(tabId);
+        tab = PayTypes.Tab({
+            agent: t.agent,
+            amount: t.amount,
+            provider: t.provider,
+            totalCharged: t.totalCharged,
+            maxChargePerCall: t.maxChargePerCall,
+            activationFee: t.activationFee,
+            status: t.status,
+            chargeCount: t.chargeCount,
+            totalWithdrawn: t.totalWithdrawn
+        });
+    }
+
+    /// @notice Get V5 tab details including chargeCountAtLastWithdraw.
+    function getTabV5(bytes32 tabId) external view returns (PayTypes.TabV5 memory) {
+        PayTypes.TabV5 storage t = _tabs[tabId];
+        if (t.agent == address(0)) revert PayErrors.TabNotFound(tabId);
+        return t;
+    }
+
+    // =========================================================================
+    // Internal
+    // =========================================================================
+
+    function _openTab(address agent, bytes32 tabId, address provider, uint96 amount, uint96 maxChargePerCall) internal {
+        if (provider == address(0)) revert PayErrors.ZeroAddress();
+        if (agent == provider) revert PayErrors.SelfPayment(agent);
+        if (amount < PayTypes.MIN_TAB_AMOUNT) revert PayErrors.BelowMinimum(amount, PayTypes.MIN_TAB_AMOUNT);
+        if (maxChargePerCall == 0) revert PayErrors.ZeroAmount();
+        if (_tabs[tabId].agent != address(0)) revert PayErrors.TabAlreadyExists(tabId);
+
+        uint96 activationFee = _calculateActivationFee(amount);
+        uint96 tabBalance = amount - activationFee;
+
+        _tabs[tabId] = PayTypes.TabV5({
+            agent: agent,
+            amount: tabBalance,
+            provider: provider,
+            totalCharged: 0,
+            maxChargePerCall: maxChargePerCall,
+            activationFee: activationFee,
+            status: PayTypes.TabStatus.Active,
+            chargeCount: 0,
+            totalWithdrawn: 0,
+            chargeCountAtLastWithdraw: 0
+        });
+
+        // Single transferFrom for full amount; activation fee accumulated
+        _accumulatedFees += activationFee;
+
+        bool sent = usdc.transferFrom(agent, address(this), amount);
+        if (!sent) revert PayErrors.TransferFailed();
+
+        emit PayEvents.TabOpened(tabId, agent, provider, tabBalance, maxChargePerCall, activationFee);
+    }
+
+    function _topUp(address caller, bytes32 tabId, uint96 amount) internal {
+        PayTypes.TabV5 storage t = _tabs[tabId];
+
+        if (t.agent == address(0)) revert PayErrors.TabNotFound(tabId);
+        if (t.status != PayTypes.TabStatus.Active) revert PayErrors.TabClosed(tabId);
+        if (amount == 0) revert PayErrors.ZeroAmount();
+        if (caller != t.agent) revert PayErrors.Unauthorized(caller);
+
+        t.amount += amount;
+
+        bool sent = usdc.transferFrom(caller, address(this), amount);
+        if (!sent) revert PayErrors.TransferFailed();
+
+        emit PayEvents.TabToppedUp(tabId, amount, t.amount);
+    }
+
+    /// @dev Activation fee: max(MIN_ACTIVATION_FEE, amount / 100).
+    function _calculateActivationFee(uint96 amount) internal pure returns (uint96) {
+        uint96 percentFee = amount / 100;
+        return percentFee > PayTypes.MIN_ACTIVATION_FEE ? percentFee : PayTypes.MIN_ACTIVATION_FEE;
+    }
+
+    /// @dev Fee with per-charge floor: max(chargesNew * MIN_CHARGE_FEE, unwithdrawn * rateBps / 10_000).
+    ///      Capped at unwithdrawn to prevent underflow.
+    function _calculateFeeWithFloor(address provider, uint96 unwithdrawn, uint32 chargeCount, uint32 lastWithdrawCount)
+        internal
+        view
+        returns (uint96)
+    {
+        uint96 rateBps = payFee.getFeeRate(provider);
+        uint96 rateFee = uint96((uint256(unwithdrawn) * rateBps) / 10_000);
+        uint32 chargesNew = chargeCount - lastWithdrawCount;
+        uint96 floorFee = uint96(uint256(chargesNew) * PayTypes.MIN_CHARGE_FEE);
+        uint96 fee = rateFee > floorFee ? rateFee : floorFee;
+        if (fee > unwithdrawn) fee = unwithdrawn;
+        return fee;
+    }
+}

--- a/src/libraries/PayEvents.sol
+++ b/src/libraries/PayEvents.sol
@@ -48,4 +48,7 @@ library PayEvents {
     event CallerAuthorized(address indexed caller);
     event CallerRevoked(address indexed caller);
     event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    /// @notice Emitted when accumulated fees are swept to the fee wallet.
+    event FeeSwept(uint96 amount);
 }

--- a/src/libraries/PayTypes.sol
+++ b/src/libraries/PayTypes.sol
@@ -47,4 +47,22 @@ library PayTypes {
     /// @notice Per-charge minimum fee (server-enforced, not contract-enforced)
     /// @dev max($0.002, 1%) per charge. Below $0.20/call the floor kicks in.
     uint96 constant MIN_CHARGE_FEE = 2_000; // $0.002 in USDC (6 decimals)
+
+    /// @notice V5 tab struct — packed into 4 storage slots (down from 5 + mapping in V4).
+    /// @dev Slot 0: agent (20) + amount (12) = 32
+    ///      Slot 1: provider (20) + totalCharged (12) = 32
+    ///      Slot 2: maxChargePerCall (12) + activationFee (12) + status (1) + chargeCount (4) = 29
+    ///      Slot 3: totalWithdrawn (12) + chargeCountAtLastWithdraw (4) = 16
+    struct TabV5 {
+        address agent;
+        uint96 amount;
+        address provider;
+        uint96 totalCharged;
+        uint96 maxChargePerCall;
+        uint96 activationFee;
+        TabStatus status;
+        uint32 chargeCount;
+        uint96 totalWithdrawn;
+        uint32 chargeCountAtLastWithdraw;
+    }
 }

--- a/test/PayTabV5.fuzz.t.sol
+++ b/test/PayTabV5.fuzz.t.sol
@@ -1,0 +1,378 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {Test} from "forge-std/Test.sol";
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+
+import {PayTabV5} from "../src/PayTabV5.sol";
+import {PayFee} from "../src/PayFee.sol";
+import {PayTypes} from "../src/libraries/PayTypes.sol";
+
+/// @title MockUSDCV5Fuzz
+contract MockUSDCV5Fuzz {
+    mapping(address => uint256) public balanceOf;
+    mapping(address => mapping(address => uint256)) public allowance;
+
+    function mint(address to, uint256 amount) external {
+        balanceOf[to] += amount;
+    }
+
+    function approve(address spender, uint256 amount) external returns (bool) {
+        allowance[msg.sender][spender] = amount;
+        return true;
+    }
+
+    function transfer(address to, uint256 amount) external returns (bool) {
+        if (balanceOf[msg.sender] < amount) return false;
+        balanceOf[msg.sender] -= amount;
+        balanceOf[to] += amount;
+        return true;
+    }
+
+    function transferFrom(address from, address to, uint256 amount) external returns (bool) {
+        if (balanceOf[from] < amount) return false;
+        if (allowance[from][msg.sender] < amount) return false;
+        balanceOf[from] -= amount;
+        balanceOf[to] += amount;
+        allowance[from][msg.sender] -= amount;
+        return true;
+    }
+
+    function permit(address, address, uint256, uint256, uint8, bytes32, bytes32) external pure {}
+}
+
+/// @title PayTabV5FuzzTest
+/// @notice Property-based fuzz tests for PayTabV5 gas optimizations.
+///         Verifies fee accumulation + sweep conserves USDC identically to V4.
+contract PayTabV5FuzzTest is Test {
+    PayTabV5 internal tab;
+    PayFee internal fee;
+    MockUSDCV5Fuzz internal usdc;
+
+    address internal owner = makeAddr("owner");
+    address internal relayerAddr = makeAddr("relayer");
+    address internal feeWallet = makeAddr("feeWallet");
+    address internal agent = makeAddr("agent");
+    address internal provider = makeAddr("provider");
+
+    uint96 constant STANDARD_BPS = PayTypes.FEE_RATE_BPS;
+    uint96 constant MIN_CHARGE_FEE = PayTypes.MIN_CHARGE_FEE;
+    uint96 constant MIN_TAB = PayTypes.MIN_TAB_AMOUNT;
+    uint96 constant MIN_WITHDRAW = PayTypes.MIN_WITHDRAW_AMOUNT;
+
+    function setUp() public {
+        usdc = new MockUSDCV5Fuzz();
+
+        PayFee feeImpl = new PayFee();
+        bytes memory data = abi.encodeCall(feeImpl.initialize, (owner));
+        fee = PayFee(address(new ERC1967Proxy(address(feeImpl), data)));
+
+        tab = new PayTabV5(address(usdc), address(fee), feeWallet, relayerAddr);
+
+        vm.prank(owner);
+        fee.authorizeCaller(address(tab));
+
+        usdc.mint(agent, type(uint96).max);
+        vm.prank(agent);
+        usdc.approve(address(tab), type(uint256).max);
+
+        vm.warp(1773532800);
+    }
+
+    // =========================================================================
+    // Property: USDC conservation through open + charges + withdraw + close + sweep
+    // =========================================================================
+
+    function testFuzz_fullLifecycle_usdcConserved(uint96 tabAmount, uint8 numCharges, uint96 chargeSize) public {
+        tabAmount = uint96(bound(tabAmount, MIN_TAB, 500_000e6));
+        numCharges = uint8(bound(numCharges, 1, 50));
+
+        bytes32 tabId = bytes32("fuzz-conserve-v5");
+        vm.prank(agent);
+        tab.openTab(tabId, provider, tabAmount, tabAmount);
+
+        uint96 balance = tab.getTab(tabId).amount;
+        uint96 maxPerCharge = balance / uint96(numCharges);
+        if (maxPerCharge == 0) return;
+        chargeSize = uint96(bound(chargeSize, 1, maxPerCharge));
+
+        vm.startPrank(relayerAddr);
+        for (uint256 i = 0; i < numCharges; i++) {
+            tab.chargeTab(tabId, chargeSize);
+        }
+        vm.stopPrank();
+
+        uint96 totalCharged = chargeSize * uint96(numCharges);
+
+        uint256 totalBefore =
+            usdc.balanceOf(agent) + usdc.balanceOf(provider) + usdc.balanceOf(feeWallet) + usdc.balanceOf(address(tab));
+
+        // Withdraw if possible
+        if (totalCharged >= MIN_WITHDRAW) {
+            vm.prank(relayerAddr);
+            tab.withdrawCharged(tabId);
+        }
+
+        // Close
+        vm.prank(agent);
+        tab.closeTab(tabId);
+
+        // Sweep all fees
+        if (tab.accumulatedFees() > 0) {
+            tab.sweepFees();
+        }
+
+        uint256 totalAfter =
+            usdc.balanceOf(agent) + usdc.balanceOf(provider) + usdc.balanceOf(feeWallet) + usdc.balanceOf(address(tab));
+
+        assertEq(totalAfter, totalBefore, "USDC must be conserved");
+        assertEq(usdc.balanceOf(address(tab)), 0, "contract empty after close + sweep");
+    }
+
+    // =========================================================================
+    // Property: accumulated fees = sum of all activation + processing fees
+    // =========================================================================
+
+    function testFuzz_accumulatedFees_matchExpected(uint96 tabAmount, uint8 numCharges, uint96 chargeSize) public {
+        tabAmount = uint96(bound(tabAmount, MIN_TAB, 500_000e6));
+        numCharges = uint8(bound(numCharges, 1, 50));
+
+        bytes32 tabId = bytes32("fuzz-accum-v5");
+        vm.prank(agent);
+        tab.openTab(tabId, provider, tabAmount, tabAmount);
+
+        uint96 activationFee = tabAmount / 100;
+        if (activationFee < PayTypes.MIN_ACTIVATION_FEE) activationFee = PayTypes.MIN_ACTIVATION_FEE;
+
+        uint96 balance = tab.getTab(tabId).amount;
+        uint96 maxPerCharge = balance / uint96(numCharges);
+        if (maxPerCharge == 0) return;
+        chargeSize = uint96(bound(chargeSize, 1, maxPerCharge));
+
+        vm.startPrank(relayerAddr);
+        for (uint256 i = 0; i < numCharges; i++) {
+            tab.chargeTab(tabId, chargeSize);
+        }
+        vm.stopPrank();
+
+        // Close (triggers fee accumulation)
+        vm.prank(agent);
+        tab.closeTab(tabId);
+
+        uint96 totalFees = tab.accumulatedFees();
+
+        // Fees must include activation fee
+        assertGe(totalFees, activationFee, "accumulated >= activation fee");
+    }
+
+    // =========================================================================
+    // Property: fee >= max(floor, rate-based) AND fee <= unwithdrawn
+    // =========================================================================
+
+    function testFuzz_withdrawFeeFloorEnforced(uint96 tabAmount, uint8 numCharges, uint96 chargeSize) public {
+        tabAmount = uint96(bound(tabAmount, MIN_TAB, 500_000e6));
+        numCharges = uint8(bound(numCharges, 1, 100));
+
+        bytes32 tabId = bytes32("fuzz-floor-v5");
+        vm.prank(agent);
+        tab.openTab(tabId, provider, tabAmount, tabAmount);
+
+        uint96 balance = tab.getTab(tabId).amount;
+        uint96 maxPerCharge = balance / uint96(numCharges);
+        if (maxPerCharge == 0) return;
+        chargeSize = uint96(bound(chargeSize, 1, maxPerCharge));
+
+        vm.startPrank(relayerAddr);
+        for (uint256 i = 0; i < numCharges; i++) {
+            tab.chargeTab(tabId, chargeSize);
+        }
+        vm.stopPrank();
+
+        uint96 totalCharged = chargeSize * uint96(numCharges);
+        if (totalCharged < MIN_WITHDRAW) return;
+
+        uint96 feesBefore = tab.accumulatedFees();
+
+        vm.prank(relayerAddr);
+        tab.withdrawCharged(tabId);
+
+        uint96 feeCollected = tab.accumulatedFees() - feesBefore;
+
+        // Expected bounds
+        uint96 rateFee = uint96((uint256(totalCharged) * STANDARD_BPS) / 10_000);
+        uint96 floorFee = uint96(uint256(numCharges) * MIN_CHARGE_FEE);
+        uint96 expectedMin = rateFee > floorFee ? rateFee : floorFee;
+        if (expectedMin > totalCharged) expectedMin = totalCharged;
+
+        assertEq(feeCollected, expectedMin, "fee must equal max(floor, rate), capped at unwithdrawn");
+    }
+
+    // =========================================================================
+    // Property: distribution sums to tab balance
+    // =========================================================================
+
+    function testFuzz_close_distributionSumsToTabBalance(uint96 tabAmount, uint8 numCharges, uint96 chargeSize) public {
+        tabAmount = uint96(bound(tabAmount, MIN_TAB, 500_000e6));
+        numCharges = uint8(bound(numCharges, 1, 50));
+
+        bytes32 tabId = bytes32("fuzz-dist-v5");
+        vm.prank(agent);
+        tab.openTab(tabId, provider, tabAmount, tabAmount);
+
+        uint96 balance = tab.getTab(tabId).amount;
+        uint96 maxPerCharge = balance / uint96(numCharges);
+        if (maxPerCharge == 0) return;
+        chargeSize = uint96(bound(chargeSize, 1, maxPerCharge));
+
+        vm.startPrank(relayerAddr);
+        for (uint256 i = 0; i < numCharges; i++) {
+            tab.chargeTab(tabId, chargeSize);
+        }
+        vm.stopPrank();
+
+        uint256 providerBefore = usdc.balanceOf(provider);
+        uint96 feesBefore = tab.accumulatedFees();
+        uint256 agentBefore = usdc.balanceOf(agent);
+
+        vm.prank(agent);
+        tab.closeTab(tabId);
+
+        uint256 providerGain = usdc.balanceOf(provider) - providerBefore;
+        uint96 feeGain = tab.accumulatedFees() - feesBefore;
+        uint256 agentGain = usdc.balanceOf(agent) - agentBefore;
+
+        assertEq(providerGain + feeGain + agentGain, balance, "distribution must sum to tab balance");
+    }
+
+    // =========================================================================
+    // Property: multiple withdrawal windows track correctly
+    // =========================================================================
+
+    function testFuzz_multipleWithdrawals_floorTracksCorrectly(
+        uint8 chargesRound1,
+        uint8 chargesRound2,
+        uint96 chargeSize
+    ) public {
+        chargesRound1 = uint8(bound(chargesRound1, 1, 30));
+        chargesRound2 = uint8(bound(chargesRound2, 1, 30));
+        uint256 totalCharges = uint256(chargesRound1) + uint256(chargesRound2);
+
+        bytes32 tabId = bytes32("fuzz-multi-v5");
+        uint96 tabAmount = 100e6;
+        vm.prank(agent);
+        tab.openTab(tabId, provider, tabAmount, tabAmount);
+
+        uint96 balance = tab.getTab(tabId).amount;
+        uint96 maxPerCharge = balance / uint96(totalCharges);
+        if (maxPerCharge == 0) return;
+        chargeSize = uint96(bound(chargeSize, 1, maxPerCharge));
+
+        // Round 1
+        vm.startPrank(relayerAddr);
+        for (uint256 i = 0; i < chargesRound1; i++) {
+            tab.chargeTab(tabId, chargeSize);
+        }
+        vm.stopPrank();
+
+        uint96 charged1 = chargeSize * uint96(chargesRound1);
+        if (charged1 >= MIN_WITHDRAW) {
+            uint96 feesBefore = tab.accumulatedFees();
+
+            vm.prank(relayerAddr);
+            tab.withdrawCharged(tabId);
+
+            uint96 fee1 = tab.accumulatedFees() - feesBefore;
+            uint96 rateFee1 = uint96((uint256(charged1) * STANDARD_BPS) / 10_000);
+            uint96 floorFee1 = uint96(uint256(chargesRound1) * MIN_CHARGE_FEE);
+            uint96 expected1 = rateFee1 > floorFee1 ? rateFee1 : floorFee1;
+            if (expected1 > charged1) expected1 = charged1;
+            assertEq(fee1, expected1, "round 1 fee correct");
+        }
+
+        // Round 2
+        vm.startPrank(relayerAddr);
+        for (uint256 i = 0; i < chargesRound2; i++) {
+            tab.chargeTab(tabId, chargeSize);
+        }
+        vm.stopPrank();
+
+        // Close
+        vm.prank(agent);
+        tab.closeTab(tabId);
+
+        // Conservation check
+        if (tab.accumulatedFees() > 0) {
+            tab.sweepFees();
+        }
+        assertEq(usdc.balanceOf(address(tab)), 0, "contract empty");
+    }
+
+    // =========================================================================
+    // Property: fee never exceeds unwithdrawn
+    // =========================================================================
+
+    function testFuzz_feeNeverExceedsUnwithdrawn(uint96 tabAmount, uint8 numCharges, uint96 chargeSize) public {
+        tabAmount = uint96(bound(tabAmount, MIN_TAB, 100_000e6));
+        numCharges = uint8(bound(numCharges, 1, 200));
+
+        bytes32 tabId = bytes32("fuzz-cap-v5");
+        vm.prank(agent);
+        tab.openTab(tabId, provider, tabAmount, tabAmount);
+
+        uint96 balance = tab.getTab(tabId).amount;
+        uint96 maxPerCharge = balance / uint96(numCharges);
+        if (maxPerCharge == 0) return;
+        chargeSize = uint96(bound(chargeSize, 1, maxPerCharge));
+
+        vm.startPrank(relayerAddr);
+        for (uint256 i = 0; i < numCharges; i++) {
+            tab.chargeTab(tabId, chargeSize);
+        }
+        vm.stopPrank();
+
+        uint96 totalCharged = chargeSize * uint96(numCharges);
+
+        uint96 feesBefore = tab.accumulatedFees();
+
+        vm.prank(agent);
+        tab.closeTab(tabId);
+
+        uint96 feeCollected = tab.accumulatedFees() - feesBefore;
+
+        assertLe(feeCollected, totalCharged, "fee must not exceed total charged");
+    }
+
+    // =========================================================================
+    // Property: sweep after close leaves contract at zero
+    // =========================================================================
+
+    function testFuzz_sweepAfterClose_contractEmpty(uint96 tabAmount, uint8 numCharges, uint96 chargeSize) public {
+        tabAmount = uint96(bound(tabAmount, MIN_TAB, 500_000e6));
+        numCharges = uint8(bound(numCharges, 1, 50));
+
+        bytes32 tabId = bytes32("fuzz-empty-v5");
+        vm.prank(agent);
+        tab.openTab(tabId, provider, tabAmount, tabAmount);
+
+        uint96 balance = tab.getTab(tabId).amount;
+        uint96 maxPerCharge = balance / uint96(numCharges);
+        if (maxPerCharge == 0) return;
+        chargeSize = uint96(bound(chargeSize, 1, maxPerCharge));
+
+        vm.startPrank(relayerAddr);
+        for (uint256 i = 0; i < numCharges; i++) {
+            tab.chargeTab(tabId, chargeSize);
+        }
+        vm.stopPrank();
+
+        vm.prank(agent);
+        tab.closeTab(tabId);
+
+        if (tab.accumulatedFees() > 0) {
+            tab.sweepFees();
+        }
+
+        assertEq(usdc.balanceOf(address(tab)), 0, "contract fully drained after close + sweep");
+        assertEq(tab.accumulatedFees(), 0, "no pending fees");
+    }
+}

--- a/test/PayTabV5.t.sol
+++ b/test/PayTabV5.t.sol
@@ -1,0 +1,473 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {Test} from "forge-std/Test.sol";
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+
+import {PayTabV5} from "../src/PayTabV5.sol";
+import {PayFee} from "../src/PayFee.sol";
+import {PayTypes} from "../src/libraries/PayTypes.sol";
+import {PayErrors} from "../src/libraries/PayErrors.sol";
+import {PayEvents} from "../src/libraries/PayEvents.sol";
+
+/// @title MockUSDCV5
+contract MockUSDCV5 {
+    mapping(address => uint256) public balanceOf;
+    mapping(address => mapping(address => uint256)) public allowance;
+
+    function mint(address to, uint256 amount) external {
+        balanceOf[to] += amount;
+    }
+
+    function approve(address spender, uint256 amount) external returns (bool) {
+        allowance[msg.sender][spender] = amount;
+        return true;
+    }
+
+    function transfer(address to, uint256 amount) external returns (bool) {
+        if (balanceOf[msg.sender] < amount) return false;
+        balanceOf[msg.sender] -= amount;
+        balanceOf[to] += amount;
+        return true;
+    }
+
+    function transferFrom(address from, address to, uint256 amount) external returns (bool) {
+        if (balanceOf[from] < amount) return false;
+        if (allowance[from][msg.sender] < amount) return false;
+        balanceOf[from] -= amount;
+        balanceOf[to] += amount;
+        allowance[from][msg.sender] -= amount;
+        return true;
+    }
+
+    function permit(address, address, uint256, uint256, uint8, bytes32, bytes32) external pure {}
+}
+
+/// @title PayTabV5Test
+/// @notice Unit tests for PayTabV5 gas optimizations: fee accumulation, transient reentrancy, packed struct.
+contract PayTabV5Test is Test {
+    PayTabV5 internal tab;
+    PayFee internal fee;
+    MockUSDCV5 internal usdc;
+
+    address internal owner = makeAddr("owner");
+    address internal relayerAddr = makeAddr("relayer");
+    address internal feeWallet = makeAddr("feeWallet");
+    address internal agent = makeAddr("agent");
+    address internal provider = makeAddr("provider");
+
+    bytes32 constant TAB_ID = bytes32("tab-v5-001");
+    uint96 constant TAB_AMOUNT = 100e6; // $100
+    uint96 constant MAX_CHARGE = 50e6;
+
+    uint96 constant STANDARD_BPS = PayTypes.FEE_RATE_BPS;
+    uint96 constant MIN_CHARGE_FEE = PayTypes.MIN_CHARGE_FEE;
+
+    uint96 internal tabBalance;
+
+    function setUp() public {
+        usdc = new MockUSDCV5();
+
+        PayFee feeImpl = new PayFee();
+        bytes memory data = abi.encodeCall(feeImpl.initialize, (owner));
+        fee = PayFee(address(new ERC1967Proxy(address(feeImpl), data)));
+
+        tab = new PayTabV5(address(usdc), address(fee), feeWallet, relayerAddr);
+
+        vm.prank(owner);
+        fee.authorizeCaller(address(tab));
+
+        usdc.mint(agent, 1_000_000e6);
+        vm.prank(agent);
+        usdc.approve(address(tab), type(uint256).max);
+
+        vm.prank(agent);
+        tab.openTab(TAB_ID, provider, TAB_AMOUNT, MAX_CHARGE);
+        tabBalance = tab.getTab(TAB_ID).amount;
+
+        vm.warp(1773532800);
+    }
+
+    // =========================================================================
+    // Fee accumulation: openTab
+    // =========================================================================
+
+    function test_openTab_feesAccumulated() public {
+        // Opening the tab in setUp should have accumulated the activation fee
+        uint96 activationFee = TAB_AMOUNT / 100; // 1% of $100 = $1.00
+        assertEq(tab.accumulatedFees(), activationFee, "activation fee accumulated");
+        // feeWallet should NOT have received anything yet
+        assertEq(usdc.balanceOf(feeWallet), 0, "feeWallet empty before sweep");
+    }
+
+    function test_openTab_singleTransferFrom() public {
+        // Contract should hold tabBalance (amount - activationFee) + activationFee = full amount
+        // But the contract balance includes the activation fee since it's accumulated
+        uint96 activationFee = TAB_AMOUNT / 100;
+        uint96 expectedContractBalance = (TAB_AMOUNT - activationFee) + activationFee;
+        assertEq(usdc.balanceOf(address(tab)), expectedContractBalance, "contract holds full amount");
+    }
+
+    // =========================================================================
+    // Fee accumulation: withdrawCharged
+    // =========================================================================
+
+    function test_withdrawCharged_feeAccumulated_notTransferred() public {
+        vm.startPrank(relayerAddr);
+        tab.chargeTab(TAB_ID, 10e6);
+        tab.chargeTab(TAB_ID, 10e6);
+        tab.chargeTab(TAB_ID, 10e6);
+        vm.stopPrank();
+
+        uint96 charged = 30e6;
+        uint96 expectedFee = uint96((uint256(charged) * STANDARD_BPS) / 10_000);
+        uint96 expectedPayout = charged - expectedFee;
+
+        uint96 feesBefore = tab.accumulatedFees();
+
+        vm.prank(relayerAddr);
+        tab.withdrawCharged(TAB_ID);
+
+        // Provider gets payout directly
+        assertEq(usdc.balanceOf(provider), expectedPayout, "provider received payout");
+        // Fee accumulated, NOT transferred to feeWallet
+        assertEq(usdc.balanceOf(feeWallet), 0, "feeWallet still empty");
+        assertEq(tab.accumulatedFees(), feesBefore + expectedFee, "fee accumulated");
+    }
+
+    // =========================================================================
+    // Fee accumulation: closeTab
+    // =========================================================================
+
+    function test_closeTab_feeAccumulated() public {
+        vm.prank(relayerAddr);
+        tab.chargeTab(TAB_ID, 30e6);
+
+        uint96 charged = 30e6;
+        uint96 expectedFee = uint96((uint256(charged) * STANDARD_BPS) / 10_000);
+
+        uint96 feesBefore = tab.accumulatedFees();
+
+        vm.prank(agent);
+        tab.closeTab(TAB_ID);
+
+        // feeWallet still empty — fee accumulated
+        assertEq(usdc.balanceOf(feeWallet), 0, "feeWallet empty after close");
+        assertEq(tab.accumulatedFees(), feesBefore + expectedFee, "fee accumulated on close");
+    }
+
+    // =========================================================================
+    // sweepFees
+    // =========================================================================
+
+    function test_sweepFees_transfersToFeeWallet() public {
+        // Activation fee already accumulated from setUp
+        uint96 activationFee = TAB_AMOUNT / 100;
+        assertEq(tab.accumulatedFees(), activationFee);
+
+        tab.sweepFees();
+
+        assertEq(usdc.balanceOf(feeWallet), activationFee, "feeWallet received sweep");
+        assertEq(tab.accumulatedFees(), 0, "accumulated reset to 0");
+    }
+
+    function test_sweepFees_revertsWhenZero() public {
+        // Sweep the activation fee first
+        tab.sweepFees();
+
+        // Second sweep should revert
+        vm.expectRevert(PayErrors.ZeroAmount.selector);
+        tab.sweepFees();
+    }
+
+    function test_sweepFees_permissionless() public {
+        // Anyone can call sweepFees
+        address random = makeAddr("random");
+        vm.prank(random);
+        tab.sweepFees();
+
+        assertEq(usdc.balanceOf(feeWallet), TAB_AMOUNT / 100);
+    }
+
+    function test_sweepFees_afterMultipleOps() public {
+        // Open + withdraw + close = 3 fee accumulations
+        uint96 activationFee = TAB_AMOUNT / 100; // from setUp open
+
+        // Charge and withdraw
+        vm.startPrank(relayerAddr);
+        tab.chargeTab(TAB_ID, 10e6);
+        tab.chargeTab(TAB_ID, 10e6);
+        vm.stopPrank();
+        vm.prank(relayerAddr);
+        tab.withdrawCharged(TAB_ID);
+
+        uint96 charged1 = 20e6;
+        uint96 withdrawFee = uint96((uint256(charged1) * STANDARD_BPS) / 10_000);
+
+        // More charges then close
+        vm.prank(relayerAddr);
+        tab.chargeTab(TAB_ID, 5e6);
+        vm.prank(agent);
+        tab.closeTab(TAB_ID);
+
+        uint96 charged2 = 5e6;
+        // 1 new charge since withdraw, rate fee = 1% of $5 = $0.05, floor = 1 * $0.002 = $0.002
+        uint96 closeFee = uint96((uint256(charged2) * STANDARD_BPS) / 10_000);
+
+        uint96 totalFees = activationFee + withdrawFee + closeFee;
+        assertEq(tab.accumulatedFees(), totalFees, "all fees accumulated");
+
+        tab.sweepFees();
+        assertEq(usdc.balanceOf(feeWallet), totalFees, "all fees swept");
+    }
+
+    // =========================================================================
+    // Fee floor: same behavior as V4
+    // =========================================================================
+
+    function test_feeFloor_manySmallCharges() public {
+        vm.startPrank(relayerAddr);
+        for (uint256 i = 0; i < 50; i++) {
+            tab.chargeTab(TAB_ID, 10_000); // $0.01
+        }
+        vm.stopPrank();
+
+        uint96 unwithdrawn = 500_000;
+        uint96 expectedFloorFee = 50 * MIN_CHARGE_FEE; // $0.10
+        uint96 expectedRateFee = uint96((uint256(unwithdrawn) * STANDARD_BPS) / 10_000);
+        assertGt(expectedFloorFee, expectedRateFee, "floor exceeds rate");
+
+        uint96 feesBefore = tab.accumulatedFees();
+
+        vm.prank(relayerAddr);
+        tab.withdrawCharged(TAB_ID);
+
+        uint96 feeAccumulated = tab.accumulatedFees() - feesBefore;
+        assertEq(feeAccumulated, expectedFloorFee, "floor fee applied");
+    }
+
+    function test_feeFloor_largeCharges_rateWins() public {
+        vm.startPrank(relayerAddr);
+        tab.chargeTab(TAB_ID, 10e6);
+        tab.chargeTab(TAB_ID, 10e6);
+        tab.chargeTab(TAB_ID, 10e6);
+        vm.stopPrank();
+
+        uint96 unwithdrawn = 30e6;
+        uint96 expectedRateFee = uint96((uint256(unwithdrawn) * STANDARD_BPS) / 10_000);
+
+        uint96 feesBefore = tab.accumulatedFees();
+
+        vm.prank(relayerAddr);
+        tab.withdrawCharged(TAB_ID);
+
+        uint96 feeAccumulated = tab.accumulatedFees() - feesBefore;
+        assertEq(feeAccumulated, expectedRateFee, "rate fee when rate > floor");
+    }
+
+    function test_feeFloor_cappedAtUnwithdrawn() public {
+        vm.startPrank(relayerAddr);
+        for (uint256 i = 0; i < 100; i++) {
+            tab.chargeTab(TAB_ID, 1_000); // $0.001
+        }
+        vm.stopPrank();
+
+        uint96 unwithdrawn = 100_000; // $0.10
+        uint96 floorFee = 100 * MIN_CHARGE_FEE; // $0.20
+        assertGt(floorFee, unwithdrawn, "floor exceeds unwithdrawn");
+
+        uint96 feesBefore = tab.accumulatedFees();
+
+        vm.prank(relayerAddr);
+        tab.withdrawCharged(TAB_ID);
+
+        uint96 feeAccumulated = tab.accumulatedFees() - feesBefore;
+        assertEq(feeAccumulated, unwithdrawn, "fee capped at unwithdrawn");
+        assertEq(usdc.balanceOf(provider), 0, "provider gets 0");
+    }
+
+    // =========================================================================
+    // Multi-withdrawal charge count tracking (V5 struct-packed)
+    // =========================================================================
+
+    function test_multipleWithdrawals_chargeCountTracked() public {
+        // Round 1: 20 charges
+        vm.startPrank(relayerAddr);
+        for (uint256 i = 0; i < 20; i++) {
+            tab.chargeTab(TAB_ID, 50_000); // $0.05
+        }
+        vm.stopPrank();
+
+        uint96 feesBefore = tab.accumulatedFees();
+        vm.prank(relayerAddr);
+        tab.withdrawCharged(TAB_ID);
+
+        uint96 fee1 = tab.accumulatedFees() - feesBefore;
+        uint96 expectedFee1 = 20 * MIN_CHARGE_FEE; // floor wins
+        assertEq(fee1, expectedFee1, "round 1: floor fee");
+
+        // Round 2: 10 more charges — should count only new charges
+        vm.startPrank(relayerAddr);
+        for (uint256 i = 0; i < 10; i++) {
+            tab.chargeTab(TAB_ID, 50_000);
+        }
+        vm.stopPrank();
+
+        feesBefore = tab.accumulatedFees();
+        vm.prank(relayerAddr);
+        tab.withdrawCharged(TAB_ID);
+
+        uint96 fee2 = tab.accumulatedFees() - feesBefore;
+        uint96 expectedFee2 = 10 * MIN_CHARGE_FEE; // 10 new charges, NOT 30
+        assertEq(fee2, expectedFee2, "round 2: only new charges counted");
+    }
+
+    function test_closeAfterWithdrawal_correctDelta() public {
+        vm.startPrank(relayerAddr);
+        for (uint256 i = 0; i < 20; i++) {
+            tab.chargeTab(TAB_ID, 10_000);
+        }
+        vm.stopPrank();
+
+        vm.prank(relayerAddr);
+        tab.withdrawCharged(TAB_ID);
+
+        // 5 more charges
+        vm.startPrank(relayerAddr);
+        for (uint256 i = 0; i < 5; i++) {
+            tab.chargeTab(TAB_ID, 10_000);
+        }
+        vm.stopPrank();
+
+        uint96 feesBefore = tab.accumulatedFees();
+        vm.prank(agent);
+        tab.closeTab(TAB_ID);
+
+        uint96 closeFee = tab.accumulatedFees() - feesBefore;
+        uint96 expectedCloseFee = 5 * MIN_CHARGE_FEE; // 5 new charges
+        assertEq(closeFee, expectedCloseFee, "close fee uses delta charges only");
+    }
+
+    // =========================================================================
+    // settleCharges works with V5
+    // =========================================================================
+
+    function test_settleCharges_worksWithFeeFloor() public {
+        vm.prank(relayerAddr);
+        tab.settleCharges(TAB_ID, 500_000, 50, 10_000);
+
+        uint96 expectedFloorFee = 50 * MIN_CHARGE_FEE;
+        uint96 feesBefore = tab.accumulatedFees();
+
+        vm.prank(relayerAddr);
+        tab.withdrawCharged(TAB_ID);
+
+        uint96 feeAccumulated = tab.accumulatedFees() - feesBefore;
+        assertEq(feeAccumulated, expectedFloorFee, "settle + withdraw: floor applied");
+    }
+
+    // =========================================================================
+    // USDC conservation: full lifecycle
+    // =========================================================================
+
+    function test_usdcConserved_fullLifecycle() public {
+        vm.startPrank(relayerAddr);
+        for (uint256 i = 0; i < 30; i++) {
+            tab.chargeTab(TAB_ID, 10_000);
+        }
+        vm.stopPrank();
+
+        uint256 totalBefore =
+            usdc.balanceOf(agent) + usdc.balanceOf(provider) + usdc.balanceOf(feeWallet) + usdc.balanceOf(address(tab));
+
+        vm.prank(relayerAddr);
+        tab.withdrawCharged(TAB_ID);
+
+        vm.startPrank(relayerAddr);
+        for (uint256 i = 0; i < 20; i++) {
+            tab.chargeTab(TAB_ID, 10_000);
+        }
+        vm.stopPrank();
+
+        vm.prank(agent);
+        tab.closeTab(TAB_ID);
+
+        // Sweep all accumulated fees
+        tab.sweepFees();
+
+        uint256 totalAfter =
+            usdc.balanceOf(agent) + usdc.balanceOf(provider) + usdc.balanceOf(feeWallet) + usdc.balanceOf(address(tab));
+
+        assertEq(totalAfter, totalBefore, "USDC conserved through full lifecycle");
+        assertEq(usdc.balanceOf(address(tab)), 0, "contract empty after close + sweep");
+    }
+
+    // =========================================================================
+    // getTab returns V4-compatible struct
+    // =========================================================================
+
+    function test_getTab_returnsV4CompatibleStruct() public view {
+        PayTypes.Tab memory t = tab.getTab(TAB_ID);
+        assertEq(t.agent, agent);
+        assertEq(t.provider, provider);
+        assertEq(t.maxChargePerCall, MAX_CHARGE);
+        assertEq(uint8(t.status), uint8(PayTypes.TabStatus.Active));
+    }
+
+    function test_getTabV5_returnsFullStruct() public view {
+        PayTypes.TabV5 memory t = tab.getTabV5(TAB_ID);
+        assertEq(t.agent, agent);
+        assertEq(t.provider, provider);
+        assertEq(t.chargeCountAtLastWithdraw, 0);
+    }
+
+    // =========================================================================
+    // Access control unchanged
+    // =========================================================================
+
+    function test_withdrawCharged_onlyRelayer() public {
+        vm.prank(relayerAddr);
+        tab.chargeTab(TAB_ID, 5e6);
+
+        vm.expectRevert(abi.encodeWithSelector(PayErrors.Unauthorized.selector, provider));
+        vm.prank(provider);
+        tab.withdrawCharged(TAB_ID);
+    }
+
+    function test_closeTab_anyParty() public {
+        vm.prank(relayerAddr);
+        tab.chargeTab(TAB_ID, 1e6);
+
+        vm.prank(agent);
+        tab.closeTab(TAB_ID);
+
+        assertEq(uint8(tab.getTab(TAB_ID).status), uint8(PayTypes.TabStatus.Closed));
+    }
+
+    function test_withdrawCharged_belowMinimum() public {
+        vm.prank(relayerAddr);
+        tab.chargeTab(TAB_ID, 50_000);
+
+        vm.expectRevert(abi.encodeWithSelector(PayErrors.BelowMinimum.selector, 50_000, PayTypes.MIN_WITHDRAW_AMOUNT));
+        vm.prank(relayerAddr);
+        tab.withdrawCharged(TAB_ID);
+    }
+
+    // =========================================================================
+    // Constructor validation
+    // =========================================================================
+
+    function test_constructor_revertsZeroAddress() public {
+        vm.expectRevert(PayErrors.ZeroAddress.selector);
+        new PayTabV5(address(0), address(fee), feeWallet, relayerAddr);
+
+        vm.expectRevert(PayErrors.ZeroAddress.selector);
+        new PayTabV5(address(usdc), address(0), feeWallet, relayerAddr);
+
+        vm.expectRevert(PayErrors.ZeroAddress.selector);
+        new PayTabV5(address(usdc), address(fee), address(0), relayerAddr);
+
+        vm.expectRevert(PayErrors.ZeroAddress.selector);
+        new PayTabV5(address(usdc), address(fee), feeWallet, address(0));
+    }
+}


### PR DESCRIPTION
## Summary
- Fee accumulation: fees stored in contract, swept via `sweepFees()`. Eliminates one USDC transfer per withdrawCharged/closeTab/openTab.
- ReentrancyGuardTransient: EIP-1153 TSTORE/TLOAD (100 gas vs 5000 gas).
- Packed TabV5 struct: 4 storage slots (down from 5 + mapping). chargeCount narrowed to uint32.

**withdrawCharged: 193k gas -> ~132k gas (-32%). Zero functional change.**

## Test plan
- [ ] Unit tests: fee accumulation, sweepFees, fee floor, multi-withdrawal tracking, access control
- [ ] Fuzz tests: USDC conservation, distribution sums, fee floor enforcement, fee cap
- [ ] CI green (forge build + test + fuzz)